### PR TITLE
Flue Gas Calculation - Excess Air or Flue Gas O2 level options

### DIFF
--- a/bindings/phast.cpp
+++ b/bindings/phast.cpp
@@ -31,6 +31,9 @@ NAN_MODULE_INIT(InitPhast) {
     Nan::Set(target, New<String>("flueGasLossesByMass").ToLocalChecked(),
              GetFunction(New<FunctionTemplate>(flueGasLossesByMass)).ToLocalChecked());
 
+    Nan::Set(target, New<String>("flueGasLossesByVolumeExcessAirConversion").ToLocalChecked(),
+             GetFunction(New<FunctionTemplate>(flueGasLossesByVolumeExcessAirConversion)).ToLocalChecked());
+
     Nan::Set(target, New<String>("gasCoolingLosses").ToLocalChecked(),
              GetFunction(New<FunctionTemplate>(gasCoolingLosses)).ToLocalChecked());
 

--- a/bindings/phast.cpp
+++ b/bindings/phast.cpp
@@ -28,11 +28,14 @@ NAN_MODULE_INIT(InitPhast) {
     Nan::Set(target, New<String>("flueGasLossesByVolume").ToLocalChecked(),
              GetFunction(New<FunctionTemplate>(flueGasLossesByVolume)).ToLocalChecked());
 
+    Nan::Set(target, New<String>("flueGasLossesByVolumeGivenO2").ToLocalChecked(),
+             GetFunction(New<FunctionTemplate>(flueGasLossesByVolumeGivenO2)).ToLocalChecked());
+
     Nan::Set(target, New<String>("flueGasLossesByMass").ToLocalChecked(),
              GetFunction(New<FunctionTemplate>(flueGasLossesByMass)).ToLocalChecked());
 
-    Nan::Set(target, New<String>("flueGasLossesByVolumeExcessAirConversion").ToLocalChecked(),
-             GetFunction(New<FunctionTemplate>(flueGasLossesByVolumeExcessAirConversion)).ToLocalChecked());
+    Nan::Set(target, New<String>("flueGasLossesByMassGivenO2").ToLocalChecked(),
+             GetFunction(New<FunctionTemplate>(flueGasLossesByMassGivenO2)).ToLocalChecked());
 
     Nan::Set(target, New<String>("gasCoolingLosses").ToLocalChecked(),
              GetFunction(New<FunctionTemplate>(gasCoolingLosses)).ToLocalChecked());

--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -543,6 +543,65 @@ NAN_METHOD(flowCalculations) {
     info.GetReturnValue().Set(r);
 }
 
+NAN_METHOD(flueGasLossesByVolumeExcessAirConversion) {
+    /**
+     * Constructor for the flue gas losses by volume with all inputs specified
+     *
+     * @param flueGasTemperature double, temperature of flue gas in °F
+     * @param excessAirPercentage double, excess air as %
+     * @param combustionAirTemperature double, temperature of combustion air in °F
+     * @param gasComposition double, percentages for CH4, C2H6, N2, H2, C3H8, C4H10_CnH2n, H2O, CO, CO2, SO2 and O2
+     * @return nothing
+     *
+     * */
+
+    inp = info[0]->ToObject();
+    // TODO find a way to get substance name legitimately
+
+    GasCompositions firstComp("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
+                          Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
+    auto error = 100.0;
+    auto const O2 = firstComp.getGasByVol("O2");
+
+    while (error > 2.0) {
+        auto const H2O = comps.getGasByWeight("H2O"), CO2 = comps.getGasByWeight("CO2");
+        auto const N2 = comps.getGasByWeight("N2"), SO2 = comps.getGasByWeight("SO2");
+        auto const O2i = O2 / (H2O + CO2 + N2 + O2 + SO2);
+        comps.calculateCompByWeight();
+        auto const excessAir = (8.52381 * O2i) / (2 - (9.52381 * O2i));
+        error = fabs(O2 - O2i) / O2;
+    }
+
+    Local<Number> retval = Nan::New(error);
+    info.GetReturnValue().Set(retval);
+}
+
+//NAN_METHOD(flueGasLossesByMassExcessAirConversion) {
+//    /**
+//     * Constructor for the flue gas losses by weight with all inputs specified
+//     *
+//     * @param flueGasTemperature double, flue gas temperature in °F
+//     * @param excessAirPercentage double, excess air as %
+//     * @param combustionAirTemperature double, combustion air temperature in °F
+//     * @param fuelTemperature double, temperature of fuel in °F
+//     * @param moistureInAirComposition double, moisture in air composition as %
+//     * @param ashDischargeTemperature double, temperature of ash discharge in °F
+//     * @param unburnedCarbonInAsh double, amount of unburned carbon in ash as %
+//     * @param fuel double, composition of: carbon, hydrogen, sulphur, inertAsh, o2, moisture and nitrogen (in %)
+//     * @return nothing
+//     *
+//     * */
+//
+//    inp = info[0]->ToObject();
+//    SolidLiquidFlueGasMaterial slfgm(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"),
+//                                     Get("fuelTemperature"), Get("moistureInAirComposition"), Get("ashDischargeTemperature"),
+//                                     Get("unburnedCarbonInAsh"), Get("carbon"), Get("hydrogen"), Get("sulphur"),
+//                                     Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
+//
+//    double heatLoss = slfgm.getHeatLoss();
+//    Local<Number> retval = Nan::New(heatLoss);
+//    info.GetReturnValue().Set(retval);
+//}
 
 NAN_METHOD(o2Enrichment) {
 

--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -564,10 +564,12 @@ NAN_METHOD(flueGasLossesByVolumeGivenO2) {
     auto const excessAir = comp.calculateExcessAir(flueGasO2);
 
     GasFlueGasMaterial fg(Get("flueGasTemperature"), excessAir * 100.0, Get("combustionAirTemperature"), comp);
-    double heatloss = fg.getHeatLoss();
+    double heatLoss = fg.getHeatLoss();
 
-    Local<Number> retval = Nan::New(heatloss);
-    info.GetReturnValue().Set(retval);
+    r = Nan::New<Object>();
+    SetR("heatLoss", heatLoss);
+    SetR("excessAir", excessAir * 100.0);
+    info.GetReturnValue().Set(r);
 }
 
 NAN_METHOD(flueGasLossesByMassGivenO2) {
@@ -602,8 +604,10 @@ NAN_METHOD(flueGasLossesByMassGivenO2) {
                                      Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
 
     double heatLoss = slfgm.getHeatLoss();
-    Local<Number> retval = Nan::New(heatLoss);
-    info.GetReturnValue().Set(retval);
+	r = Nan::New<Object>();
+    SetR("heatLoss", heatLoss);
+    SetR("excessAir", excessAir * 100.0);
+    info.GetReturnValue().Set(r);
 }
 
 NAN_METHOD(o2Enrichment) {

--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -172,57 +172,6 @@ NAN_METHOD(fixtureLosses) {
     info.GetReturnValue().Set(retval);
 }
 
-NAN_METHOD(flueGasLossesByVolume) {
-    /**
-     * Constructor for the flue gas losses by volume with all inputs specified
-     *
-     * @param flueGasTemperature double, temperature of flue gas in °F
-     * @param excessAirPercentage double, excess air as %
-     * @param combustionAirTemperature double, temperature of combustion air in °F
-     * @param gasComposition double, percentages for CH4, C2H6, N2, H2, C3H8, C4H10_CnH2n, H2O, CO, CO2, SO2 and O2
-     * @return nothing
-     *
-     * */
-
-    inp = info[0]->ToObject();
-    // TODO find a way to get substance name legitimately
-    GasCompositions comps("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
-                          Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
-
-    GasFlueGasMaterial fg(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"), comps);
-
-    double heatLoss = fg.getHeatLoss();
-    Local<Number> retval = Nan::New(heatLoss);
-    info.GetReturnValue().Set(retval);
-}
-
-NAN_METHOD(flueGasLossesByMass) {
-    /**
-     * Constructor for the flue gas losses by weight with all inputs specified
-     *
-     * @param flueGasTemperature double, flue gas temperature in °F
-     * @param excessAirPercentage double, excess air as %
-     * @param combustionAirTemperature double, combustion air temperature in °F
-     * @param fuelTemperature double, temperature of fuel in °F
-     * @param moistureInAirComposition double, moisture in air composition as %
-     * @param ashDischargeTemperature double, temperature of ash discharge in °F
-     * @param unburnedCarbonInAsh double, amount of unburned carbon in ash as %
-     * @param fuel double, composition of: carbon, hydrogen, sulphur, inertAsh, o2, moisture and nitrogen (in %)
-     * @return nothing
-     *
-     * */
-
-    inp = info[0]->ToObject();
-    SolidLiquidFlueGasMaterial slfgm(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"),
-                                     Get("fuelTemperature"), Get("moistureInAirComposition"), Get("ashDischargeTemperature"),
-                                     Get("unburnedCarbonInAsh"), Get("carbon"), Get("hydrogen"), Get("sulphur"),
-                                     Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
-
-    double heatLoss = slfgm.getHeatLoss();
-    Local<Number> retval = Nan::New(heatLoss);
-    info.GetReturnValue().Set(retval);
-}
-
 NAN_METHOD(gasCoolingLosses) {
 /**
   * Constructor for the gas cooling losses (including air) with all inputs specified
@@ -543,7 +492,58 @@ NAN_METHOD(flowCalculations) {
     info.GetReturnValue().Set(r);
 }
 
-NAN_METHOD(flueGasLossesByVolumeExcessAirConversion) {
+NAN_METHOD(flueGasLossesByVolume) {
+	/**
+	 * Constructor for the flue gas losses by volume with all inputs specified
+	 *
+	 * @param flueGasTemperature double, temperature of flue gas in °F
+	 * @param excessAirPercentage double, excess air as %
+	 * @param combustionAirTemperature double, temperature of combustion air in °F
+	 * @param gasComposition double, percentages for CH4, C2H6, N2, H2, C3H8, C4H10_CnH2n, H2O, CO, CO2, SO2 and O2
+	 * @return heatLoss / available heat
+	 *
+	 * */
+
+	inp = info[0]->ToObject();
+	// TODO find a way to get substance name legitimately
+	GasCompositions comps("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
+	                      Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
+
+	GasFlueGasMaterial fg(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"), comps);
+
+	double heatLoss = fg.getHeatLoss();
+	Local<Number> retval = Nan::New(heatLoss);
+	info.GetReturnValue().Set(retval);
+}
+
+NAN_METHOD(flueGasLossesByMass) {
+	/**
+	 * Constructor for the flue gas losses by weight with all inputs specified
+	 *
+	 * @param flueGasTemperature double, flue gas temperature in °F
+	 * @param excessAirPercentage double, excess air as %
+	 * @param combustionAirTemperature double, combustion air temperature in °F
+	 * @param fuelTemperature double, temperature of fuel in °F
+	 * @param moistureInAirComposition double, moisture in air composition as %
+	 * @param ashDischargeTemperature double, temperature of ash discharge in °F
+	 * @param unburnedCarbonInAsh double, amount of unburned carbon in ash as %
+	 * @param fuel double, composition of: carbon, hydrogen, sulphur, inertAsh, o2, moisture and nitrogen (in %)
+	 * @return heat loss / available heat
+	 *
+	 * */
+
+	inp = info[0]->ToObject();
+	SolidLiquidFlueGasMaterial slfgm(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"),
+	                                 Get("fuelTemperature"), Get("moistureInAirComposition"), Get("ashDischargeTemperature"),
+	                                 Get("unburnedCarbonInAsh"), Get("carbon"), Get("hydrogen"), Get("sulphur"),
+	                                 Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
+
+	double heatLoss = slfgm.getHeatLoss();
+	Local<Number> retval = Nan::New(heatLoss);
+	info.GetReturnValue().Set(retval);
+}
+
+NAN_METHOD(flueGasLossesByVolumeGivenO2) {
     /**
      * Constructor for the flue gas losses by volume with all inputs specified
      *
@@ -560,39 +560,51 @@ NAN_METHOD(flueGasLossesByVolumeExcessAirConversion) {
     GasCompositions comp("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
                           Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
 
-    auto const flueGasO2 = Get("flueGasO2Percentage");
+    auto const flueGasO2 = Get("flueGasO2") / 100.0;
     auto const excessAir = comp.calculateExcessAir(flueGasO2);
 
-    Local<Number> retval = Nan::New(excessAir);
+    GasFlueGasMaterial fg(Get("flueGasTemperature"), excessAir * 100.0, Get("combustionAirTemperature"), comp);
+    double heatloss = fg.getHeatLoss();
+
+    Local<Number> retval = Nan::New(heatloss);
     info.GetReturnValue().Set(retval);
 }
 
-//NAN_METHOD(flueGasLossesByMassExcessAirConversion) {
-//    /**
-//     * Constructor for the flue gas losses by weight with all inputs specified
-//     *
-//     * @param flueGasTemperature double, flue gas temperature in °F
-//     * @param excessAirPercentage double, excess air as %
-//     * @param combustionAirTemperature double, combustion air temperature in °F
-//     * @param fuelTemperature double, temperature of fuel in °F
-//     * @param moistureInAirComposition double, moisture in air composition as %
-//     * @param ashDischargeTemperature double, temperature of ash discharge in °F
-//     * @param unburnedCarbonInAsh double, amount of unburned carbon in ash as %
-//     * @param fuel double, composition of: carbon, hydrogen, sulphur, inertAsh, o2, moisture and nitrogen (in %)
-//     * @return nothing
-//     *
-//     * */
-//
-//    inp = info[0]->ToObject();
-//    SolidLiquidFlueGasMaterial slfgm(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"),
-//                                     Get("fuelTemperature"), Get("moistureInAirComposition"), Get("ashDischargeTemperature"),
-//                                     Get("unburnedCarbonInAsh"), Get("carbon"), Get("hydrogen"), Get("sulphur"),
-//                                     Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
-//
-//    double heatLoss = slfgm.getHeatLoss();
-//    Local<Number> retval = Nan::New(heatLoss);
-//    info.GetReturnValue().Set(retval);
-//}
+NAN_METHOD(flueGasLossesByMassGivenO2) {
+    /**
+     * Constructor for the flue gas losses by weight with all inputs specified
+     *
+     * @param flueGasTemperature double, flue gas temperature in °F
+     * @param excessAirPercentage double, excess air as %
+     * @param combustionAirTemperature double, combustion air temperature in °F
+     * @param fuelTemperature double, temperature of fuel in °F
+     * @param moistureInAirComposition double, moisture in air composition as %
+     * @param ashDischargeTemperature double, temperature of ash discharge in °F
+     * @param unburnedCarbonInAsh double, amount of unburned carbon in ash as %
+     * @param fuel double, composition of: carbon, hydrogen, sulphur, inertAsh, o2, moisture and nitrogen (in %)
+     * @return nothing
+     *
+     * */
+
+    inp = info[0]->ToObject();
+	auto const flueGasO2 = Get("flueGasO2") / 100.0;
+
+    auto const excessAir = SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2(flueGasO2,
+                                                                                       Get("moistureInAirComposition"),
+                                                                                       Get("carbon"), Get("hydrogen"),
+                                                                                       Get("sulphur"), Get("inertAsh"),
+                                                                                       Get("o2"), Get("moisture"),
+                                                                                       Get("nitrogen"));
+
+    SolidLiquidFlueGasMaterial slfgm(Get("flueGasTemperature"), excessAir * 100.0, Get("combustionAirTemperature"),
+                                     Get("fuelTemperature"), Get("moistureInAirComposition"), Get("ashDischargeTemperature"),
+                                     Get("unburnedCarbonInAsh"), Get("carbon"), Get("hydrogen"), Get("sulphur"),
+                                     Get("inertAsh"), Get("o2"), Get("moisture"), Get("nitrogen"));
+
+    double heatLoss = slfgm.getHeatLoss();
+    Local<Number> retval = Nan::New(heatLoss);
+    info.GetReturnValue().Set(retval);
+}
 
 NAN_METHOD(o2Enrichment) {
 

--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -556,23 +556,14 @@ NAN_METHOD(flueGasLossesByVolumeExcessAirConversion) {
      * */
 
     inp = info[0]->ToObject();
-    // TODO find a way to get substance name legitimately
 
-    GasCompositions firstComp("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
+    GasCompositions comp("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
                           Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
-    auto error = 100.0;
-    auto const O2 = firstComp.getGasByVol("O2");
 
-    while (error > 2.0) {
-        auto const H2O = comps.getGasByWeight("H2O"), CO2 = comps.getGasByWeight("CO2");
-        auto const N2 = comps.getGasByWeight("N2"), SO2 = comps.getGasByWeight("SO2");
-        auto const O2i = O2 / (H2O + CO2 + N2 + O2 + SO2);
-        comps.calculateCompByWeight();
-        auto const excessAir = (8.52381 * O2i) / (2 - (9.52381 * O2i));
-        error = fabs(O2 - O2i) / O2;
-    }
+    auto const flueGasO2 = Get("flueGasO2Percentage");
+    auto const excessAir = comp.calculateExcessAir(flueGasO2);
 
-    Local<Number> retval = Nan::New(error);
+    Local<Number> retval = Nan::New(excessAir);
     info.GetReturnValue().Set(retval);
 }
 

--- a/include/calculator/losses/GasFlueGasMaterial.h
+++ b/include/calculator/losses/GasFlueGasMaterial.h
@@ -132,15 +132,7 @@ public:
 		return gas->second->compByVol;
 	}
 
-//	double getGasByWeight(const std::string & gasName) const {
-//		auto const gas = gasses.find(gasName);
-//		if (gas == gasses.end()) {
-//			throw std::runtime_error("Cannot find " + gasName + " in gasses");
-//		}
-//		return gas->second->compByWeight;
-//	}
-
-	double calculateExcessAir(const double O2userInput);
+	double calculateExcessAir(const double flueGasO2);
 
     /**
      * Gets the name of substance

--- a/include/calculator/losses/GasFlueGasMaterial.h
+++ b/include/calculator/losses/GasFlueGasMaterial.h
@@ -132,6 +132,16 @@ public:
 		return gas->second->compByVol;
 	}
 
+//	double getGasByWeight(const std::string & gasName) const {
+//		auto const gas = gasses.find(gasName);
+//		if (gas == gasses.end()) {
+//			throw std::runtime_error("Cannot find " + gasName + " in gasses");
+//		}
+//		return gas->second->compByWeight;
+//	}
+
+	double calculateExcessAir(const double O2userInput);
+
     /**
      * Gets the name of substance
      *
@@ -166,16 +176,16 @@ private:
 	void calculateCompByWeight();
 	double calculateSensibleHeat(const double combustionAirTemp);
 	double calculateHeatCombustionAir(const double combustionAirTemp, const double excessAir);
-	double calculateHeatingValueFuel();
 	void calculateMassFlueGasComponents(const double excessAir);
+	double calculateHeatingValueFuel();
 	void calculateEnthalpy();
 	double calculateTotalHeatContentFlueGas(const double flueGasTemperature);
 
 	// the hash map holds a reference to the GasProperties below for easier iterable summations
 	std::unordered_map <std::string, std::shared_ptr<GasProperties>> gasses;
 	int id;
-	const std::string substance;
-	const double totalPercent;
+	std::string substance;
+	double totalPercent;
 	double hH2Osat, tH2Osat;
 	double mH2O = 0, mCO2 = 0, mO2 = 0, mN2 = 0, mSO2 = 0;
 	std::shared_ptr<GasProperties> CH4, C2H6, N2, H2, C3H8, C4H10_CnH2n, H2O, CO, CO2, SO2, O2;

--- a/include/calculator/losses/SolidLiquidFlueGasMaterial.h
+++ b/include/calculator/losses/SolidLiquidFlueGasMaterial.h
@@ -50,6 +50,38 @@ public:
 			nitrogen(nitrogen / 100)
 	{}
 
+//	SolidLiquidFlueGasMaterial(
+//			const bool
+//			const double flueGasTemperature,
+//			const double flueGasO2,
+//			const double combustionAirTemperature,
+//			const double fuelTemperature,
+//			const double moistureInAirCombustion,
+//			const double ashDischargeTemperature,
+//			const double unburnedCarbonInAsh,
+//			const double carbon,
+//			const double hydrogen,
+//			const double sulphur,
+//			const double inertAsh,
+//			const double o2,
+//			const double moisture,
+//			const double nitrogen) :
+//			flueGasTemperature(flueGasTemperature),
+//			excessAirPercentage(excessAirPercentage / 100.0),
+//			combustionAirTemperature(combustionAirTemperature),
+//			fuelTemperature(fuelTemperature),
+//			moistureInAirCombustion(moistureInAirCombustion),
+//			ashDischargeTemperature(ashDischargeTemperature),
+//			unburnedCarbonInAsh(unburnedCarbonInAsh / 100.0),
+//			carbon(carbon / 100),
+//			hydrogen(hydrogen / 100),
+//			sulphur(sulphur / 100),
+//			inertAsh(inertAsh / 100),
+//			o2(o2 / 100),
+//			moisture(moisture / 100),
+//			nitrogen(nitrogen / 100)
+//	{}
+
 	/**
      * Gets the total heat loss
      *

--- a/include/calculator/losses/SolidLiquidFlueGasMaterial.h
+++ b/include/calculator/losses/SolidLiquidFlueGasMaterial.h
@@ -9,7 +9,7 @@ public:
 	 * Constructor for the SolidLiquidFlueGasMaterial losses with all inputs specified
 	 *
 	 * @param flueGasTemperature - double, Furnace Flue Gas Temperature in °F
-	 * @param excessAirPercentage - double, Percent Excess Air, expressed in normal percentage (i.e. 9% as 9 instead of 0.09)
+	 * @param excessAir - double, Percent Excess Air, expressed in normal percentage (i.e. 9% as 9 instead of 0.09)
 	 * @param combustionAirTemperature - double, Combustion Air Temperature in °F
 	 * @param fuelTemperature - double, fuel Temperature in °F
 	 * @param moistureInAirCombustion - double, moisture in Air Combustion as %
@@ -21,7 +21,7 @@ public:
 	 * */
 	SolidLiquidFlueGasMaterial(
 			const double flueGasTemperature,
-			const double excessAirPercentage,
+			const double excessAir,
 			const double combustionAirTemperature,
 			const double fuelTemperature,
 			const double moistureInAirCombustion,
@@ -35,7 +35,7 @@ public:
 			const double moisture,
 			const double nitrogen) :
 			flueGasTemperature(flueGasTemperature),
-			excessAirPercentage(excessAirPercentage / 100.0),
+			excessAir(excessAir / 100.0),
 			combustionAirTemperature(combustionAirTemperature),
 			fuelTemperature(fuelTemperature),
 			moistureInAirCombustion(moistureInAirCombustion),
@@ -50,37 +50,15 @@ public:
 			nitrogen(nitrogen / 100)
 	{}
 
-//	SolidLiquidFlueGasMaterial(
-//			const bool
-//			const double flueGasTemperature,
-//			const double flueGasO2,
-//			const double combustionAirTemperature,
-//			const double fuelTemperature,
-//			const double moistureInAirCombustion,
-//			const double ashDischargeTemperature,
-//			const double unburnedCarbonInAsh,
-//			const double carbon,
-//			const double hydrogen,
-//			const double sulphur,
-//			const double inertAsh,
-//			const double o2,
-//			const double moisture,
-//			const double nitrogen) :
-//			flueGasTemperature(flueGasTemperature),
-//			excessAirPercentage(excessAirPercentage / 100.0),
-//			combustionAirTemperature(combustionAirTemperature),
-//			fuelTemperature(fuelTemperature),
-//			moistureInAirCombustion(moistureInAirCombustion),
-//			ashDischargeTemperature(ashDischargeTemperature),
-//			unburnedCarbonInAsh(unburnedCarbonInAsh / 100.0),
-//			carbon(carbon / 100),
-//			hydrogen(hydrogen / 100),
-//			sulphur(sulphur / 100),
-//			inertAsh(inertAsh / 100),
-//			o2(o2 / 100),
-//			moisture(moisture / 100),
-//			nitrogen(nitrogen / 100)
-//	{}
+	/**
+     * Calculates excess air percentage given flue gas O2 levels
+     *
+     * @return double, calculated excess air percentage
+     */
+	static double calculateExcessAirFromFlueGasO2(
+			const double flueGasO2, const double carbon, const double hydrogen, const double sulphur,
+			const double inertAsh, const double o2, const double moisture, const double nitrogen,
+			const double moistureInAirCombustion);
 
 	/**
      * Gets the total heat loss
@@ -115,7 +93,7 @@ public:
      *
      * @return double, excess air as %
      */
-	double getExcessAirPercentage() const { return excessAirPercentage; }
+	double getExcessAir() const { return excessAir; }
 
 	/**
      * Gets the combustion air temperature
@@ -235,7 +213,7 @@ public:
      *
      * @return nothing
      */
-	void setExcessAirPercentage( const double excessAir ) { excessAirPercentage = excessAir; }
+	void setExcessAir( const double excessAir ) { this->excessAir = excessAir; }
 
 	/**
      * Sets the combustion air temperature
@@ -306,7 +284,7 @@ private:
 
 	int id = 0;
 	std::string substance = "UndefinedSubstance";
-	double flueGasTemperature, excessAirPercentage, combustionAirTemperature;
+	double flueGasTemperature, excessAir, combustionAirTemperature;
 	double fuelTemperature, moistureInAirCombustion, ashDischargeTemperature, unburnedCarbonInAsh;
 	const double carbon, hydrogen, sulphur, inertAsh, o2, moisture, nitrogen;
 };

--- a/src/calculator/losses/GasFlueGasMaterial.cpp
+++ b/src/calculator/losses/GasFlueGasMaterial.cpp
@@ -14,6 +14,19 @@ std::string GasCompositions::getSubstance() const {
     return substance;
 }
 
+double GasCompositions::calculateExcessAir(const double O2userInput) {
+    calculateCompByWeight();
+    auto excessAir = (8.52381 * O2userInput) / (2 - (9.52381 * O2userInput));
+    auto error = 100.0;
+
+    while (error > 2.0) {
+        calculateMassFlueGasComponents(excessAir);
+        auto const O2i = mO2 / (mH2O + mCO2 + mN2 + mO2 + mSO2);
+        error = (O2userInput - O2i) / 2;
+    }
+	return excessAir;
+}
+
 void GasCompositions::calculateCompByWeight() {
     double summationDenom = 0;
     for ( auto const & compound : gasses ) {

--- a/src/calculator/losses/GasFlueGasMaterial.cpp
+++ b/src/calculator/losses/GasFlueGasMaterial.cpp
@@ -14,17 +14,18 @@ std::string GasCompositions::getSubstance() const {
     return substance;
 }
 
-double GasCompositions::calculateExcessAir(const double O2userInput) {
+double GasCompositions::calculateExcessAir(const double flueGasO2) {
     calculateCompByWeight();
-    double excessAir = (8.52381 * O2userInput) / (2 - (9.52381 * O2userInput));
+    double excessAir = (8.52381 * flueGasO2) / (2 - (9.52381 * flueGasO2));
 	if (excessAir == 0) return 0;
 
-    while (true) {
+	// loop a max of 100 times, this loop doesn't take more than roughly 10 iterations right now
+    for (auto i = 0; i < 100; i++) {
         calculateMassFlueGasComponents(excessAir);
         auto const O2i = mO2 / (mH2O + mCO2 + mN2 + mO2 + mSO2);
-        auto const error = fabs((O2userInput - O2i) / O2userInput);
+        auto const error = fabs((flueGasO2 - O2i) / flueGasO2);
         if (error < 0.02) break;
-	    if (O2i > O2userInput) {
+        if (O2i > flueGasO2) {
             excessAir -= (excessAir * 0.01);
         } else {
             excessAir += (excessAir * 0.01);

--- a/src/calculator/losses/SolidLiquidFlueGasMaterial.cpp
+++ b/src/calculator/losses/SolidLiquidFlueGasMaterial.cpp
@@ -1,6 +1,49 @@
 #include "calculator/losses/SolidLiquidFlueGasMaterial.h"
 #include <cmath>
 
+double SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2(
+		const double flueGasO2, const double carbon, const double hydrogen, const double sulphur, const double inertAsh,
+		const double o2, const double moisture, const double nitrogen, const double moistureInAirCombustion) {
+
+	// adjust input by weight - step 1
+	const double percentTotalFuelComponents = carbon + hydrogen + sulphur + inertAsh + o2 + moisture + nitrogen;
+	const double carbonBar = carbon / percentTotalFuelComponents;
+	const double hydrogenBar = hydrogen / percentTotalFuelComponents;
+	const double sulphurBar = sulphur / percentTotalFuelComponents;
+	const double o2Bar = o2 / percentTotalFuelComponents;
+	const double moistureBar = moisture / percentTotalFuelComponents;
+
+	double excessAir = (8.52381 * flueGasO2) / (2 - (9.52381 * flueGasO2));
+	if (excessAir == 0) return 0;
+
+	// loop a max of 100 times, this loop doesn't take more than roughly 10 iterations right now
+	for (auto i = 0; i < 100; i++) {
+		// steps 2 and 3
+		const double o2sair = carbonBar * (32.0 / 12) + hydrogenBar * 8 + sulphurBar - o2Bar;
+		const double n2sair = o2sair * (76.85 / 23.15);
+		const double msair = o2sair + n2sair;
+		const double mCombustionAir = msair * (1 + excessAir);
+
+		// steps 4 and 5
+		const double mCO2 = carbonBar * (44.0 / 12);
+		const double mH2O = hydrogenBar * 9 + moistureBar + (moistureInAirCombustion / 100.0) * mCombustionAir;
+		const double mSO2 = sulphurBar * 2;
+		const double mO2 = o2sair * excessAir;
+		const double mN2 = n2sair * (1 + excessAir);
+
+		auto const O2i = mO2 / (mH2O + mCO2 + mN2 + mO2 + mSO2);
+		auto const error = fabs((flueGasO2 - O2i) / flueGasO2);
+		if (error < 0.02) break;
+		if (O2i > flueGasO2) {
+			excessAir -= (excessAir * 0.01);
+		} else {
+			excessAir += (excessAir * 0.01);
+		}
+	}
+
+	return excessAir;
+}
+
 double SolidLiquidFlueGasMaterial::getHeatLoss() {
 	// adjust input by weight - step 1
 	const double percentTotalFuelComponents = carbon + hydrogen + sulphur + inertAsh + o2 + moisture + nitrogen;
@@ -16,7 +59,7 @@ double SolidLiquidFlueGasMaterial::getHeatLoss() {
 	const double o2sair = carbonBar * (32.0 / 12) + hydrogenBar * 8 + sulphurBar - o2Bar;
 	const double n2sair = o2sair * (76.85 / 23.15);
 	const double msair = o2sair + n2sair;
-	const double mCombustionAir = msair * (1 + excessAirPercentage);
+	const double mCombustionAir = msair * (1 + excessAir);
 	const double hCombustionAir = mCombustionAir * cpCombustionAir * (combustionAirTemperature - 60) / 0.075;
 
 	// steps 4 and 5
@@ -24,8 +67,8 @@ double SolidLiquidFlueGasMaterial::getHeatLoss() {
 	const double mCO2 = carbonBar * (44.0 / 12);
 	const double mH2O = hydrogenBar * 9 + moistureBar + (moistureInAirCombustion / 100.0) * mCombustionAir;
 	const double mSO2 = sulphurBar * 2;
-	const double mO2 = o2sair * excessAirPercentage;
-	const double mN2 = n2sair * (1 + excessAirPercentage);
+	const double mO2 = o2sair * excessAir;
+	const double mN2 = n2sair * (1 + excessAir);
 
 	const double pH2O = (mH2O / 0.047636) /
 			(mCO2 / 0.116367 + mH2O / 0.047636 + mN2 / 0.074077 + mO2 / 0.084611 + mSO2 / 0.169381);

--- a/tests/GasFlueGasMaterial.unit.cpp
+++ b/tests/GasFlueGasMaterial.unit.cpp
@@ -4,7 +4,6 @@
 TEST_CASE( "Calculate Heat Loss for flue gas Losses", "[Heat Loss]" ) {
 	GasCompositions composition("unit test gas", 94.1, 2.4, 1.41, 0.03, 0.49, 0.29, 0, 0.42, 0.71, 0, 0);
 
-	//added two zeros in front
 	REQUIRE(composition.calculateExcessAir(0.005) == Approx(0.0231722));
 	REQUIRE(composition.calculateExcessAir(0.03) == Approx(0.1552234));
 	REQUIRE(composition.calculateExcessAir(0.07) == Approx(0.451975));

--- a/tests/GasFlueGasMaterial.unit.cpp
+++ b/tests/GasFlueGasMaterial.unit.cpp
@@ -4,9 +4,13 @@
 TEST_CASE( "Calculate Heat Loss for flue gas Losses", "[Heat Loss]" ) {
 	GasCompositions composition("unit test gas", 94.1, 2.4, 1.41, 0.03, 0.49, 0.29, 0, 0.42, 0.71, 0, 0);
 
+	//added two zeros in front
 	REQUIRE(composition.calculateExcessAir(0.005) == Approx(0.0231722));
 	REQUIRE(composition.calculateExcessAir(0.03) == Approx(0.1552234));
 	REQUIRE(composition.calculateExcessAir(0.07) == Approx(0.451975));
 
+	REQUIRE(GasFlueGasMaterial(700, 2.31722095, 125, composition).getHeatLoss() == Approx(0.7758857341));
+	REQUIRE(GasFlueGasMaterial(700, 15.52234415, 125, composition).getHeatLoss() == Approx(0.7622712145));
+	REQUIRE(GasFlueGasMaterial(700, 45.19750365, 125, composition).getHeatLoss() == Approx(0.7316834966));
 	REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition).getHeatLoss() == Approx(0.76899));
 }

--- a/tests/GasFlueGasMaterial.unit.cpp
+++ b/tests/GasFlueGasMaterial.unit.cpp
@@ -4,5 +4,9 @@
 TEST_CASE( "Calculate Heat Loss for flue gas Losses", "[Heat Loss]" ) {
 	GasCompositions composition("unit test gas", 94.1, 2.4, 1.41, 0.03, 0.49, 0.29, 0, 0.42, 0.71, 0, 0);
 
+	REQUIRE(composition.calculateExcessAir(0.005) == Approx(0.0231722));
+	REQUIRE(composition.calculateExcessAir(0.03) == Approx(0.1552234));
+	REQUIRE(composition.calculateExcessAir(0.07) == Approx(0.451975));
+
 	REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition).getHeatLoss() == Approx(0.76899));
 }

--- a/tests/SolidLiquidFlueGasMaterial.unit.cpp
+++ b/tests/SolidLiquidFlueGasMaterial.unit.cpp
@@ -2,5 +2,17 @@
 #include <calculator/losses/SolidLiquidFlueGasMaterial.h>
 
 TEST_CASE( "Calculate SolidLiquidFlueGasMaterial Heat Loss", "[Heat Loss]" ) {
+	auto excessAir = SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2(0.005, 1.0, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5);
+	REQUIRE(excessAir == Approx(0.0229427817));
+
+	excessAir = SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2(0.03, 1.0, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5);
+	REQUIRE(excessAir == Approx(0.1536865757));
+
+	excessAir = SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2(0.07, 1.0, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5);
+	REQUIRE(excessAir == Approx(0.4475000362));
+
+	REQUIRE(SolidLiquidFlueGasMaterial(700, 2.29427817, 125, 70, 1.0, 100, 1.5, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5).getHeatLoss() == Approx(0.8297708724));
+	REQUIRE(SolidLiquidFlueGasMaterial(700, 15.36865757, 125, 70, 1.0, 100, 1.5, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5).getHeatLoss() == Approx(0.8151987637));
+	REQUIRE(SolidLiquidFlueGasMaterial(700, 44.75000362, 125, 70, 1.0, 100, 1.5, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5).getHeatLoss() == Approx(0.7824331922));
 	REQUIRE(SolidLiquidFlueGasMaterial(700, 9.0, 125, 70, 1.0, 100, 1.5, 75.0, 5.0, 1.0, 9.0, 7.0, 0.0, 1.5).getHeatLoss() == Approx(0.8223));
 }

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -82,16 +82,24 @@ test('flueGasByMass', function (t) {
 });
 
 test('flueGasByVolumeExcessAirConversion', function (t) {
-    t.plan(2);
+    t.plan(4);
     t.type(bindings.flueGasLossesByVolumeExcessAirConversion, 'function');
     var inp = {
-        flueGasTemperature: 700, excessAirPercentage: 0, combustionAirTemperature: 125, substance: 'test substance',
+        flueGasTemperature: 700, flueGasO2Percentage: 0.005, combustionAirTemperature: 125, substance: 'test substance',
         CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0,
-        O2: 3.0
+        O2: 0
     };
 
     var res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
-    t.equal(res, 0, res + ' != 0');
+    t.equal(res, 0.023172209488353974, res + ' != 0.023172209488353974');
+
+    inp['flueGasO2Percentage'] = 0.03;
+    res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
+    t.equal(res, 0.1552234414568954, res + ' != 0.1552234414568954');
+
+    inp['flueGasO2Percentage'] = 0.07;
+    res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
+    t.equal(res, 0.4519750365493759, res + ' != 0.4519750365493759');
 });
 
 test('gasCoolingLosses', function (t) {

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -81,26 +81,52 @@ test('flueGasByMass', function (t) {
     t.equal(res, 0.8222977480707968, res + ' != 0.8222977480707968');
 });
 
-test('flueGasByVolumeExcessAirConversion', function (t) {
+test('flueGasLossesByVolumeGivenO2', function (t) {
     t.plan(4);
-    t.type(bindings.flueGasLossesByVolumeExcessAirConversion, 'function');
+    t.type(bindings.flueGasLossesByVolumeGivenO2, 'function');
     var inp = {
-        flueGasTemperature: 700, flueGasO2Percentage: 0.005, combustionAirTemperature: 125, substance: 'test substance',
+        flueGasTemperature: 700, flueGasO2: 0.5, combustionAirTemperature: 125, substance: 'test substance',
         CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0,
         O2: 0
     };
 
-    var res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
-    t.equal(res, 0.023172209488353974, res + ' != 0.023172209488353974');
+    // GasCompositions composition("unit test gas", 94.1, 2.4, 1.41, 0.03, 0.49, 0.29, 0, 0.42, 0.71, 0, 0);
+    // REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition).getHeatLoss() == Approx(0.76899));
 
-    inp['flueGasO2Percentage'] = 0.03;
-    res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
-    t.equal(res, 0.1552234414568954, res + ' != 0.1552234414568954');
+    var res = bindings.flueGasLossesByVolumeGivenO2(inp);
+    t.equal(res, 0.7758857340516403, res + ' != 0.7758857340516403');
 
-    inp['flueGasO2Percentage'] = 0.07;
-    res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
-    t.equal(res, 0.4519750365493759, res + ' != 0.4519750365493759');
+    inp['flueGasO2'] = 3.0;
+    res = bindings.flueGasLossesByVolumeGivenO2(inp);
+    t.equal(res, 0.7622712144825897, res + ' != 0.7622712144825897');
+
+    inp['flueGasO2'] = 7.0;
+    res = bindings.flueGasLossesByVolumeGivenO2(inp);
+    t.equal(res, 0.731683496609056, res + ' != 0.731683496609056');
 });
+
+test('flueGasLossesByMassGivenO2', function (t) {
+    t.plan(4);
+    t.type(bindings.flueGasLossesByMassGivenO2, 'function');
+
+    var inp = {
+        flueGasTemperature: 700, flueGasO2: 0.5, combustionAirTemperature: 125, fuelTemperature: 70,
+        moistureInAirComposition: 1.0, ashDischargeTemperature: 100, unburnedCarbonInAsh: 1.5,
+        carbon: 75.0, hydrogen: 5.0, sulphur: 1.0, inertAsh: 9.0, o2: 7.0, moisture: 0.0, nitrogen: 1.5
+    };
+
+    var res = bindings.flueGasLossesByMassGivenO2(inp);
+    t.equal(res, 0.8297708723770466, res + ' != 0.8297708723770466');
+
+    inp['flueGasO2'] = 3.0;
+    res = bindings.flueGasLossesByMassGivenO2(inp);
+    t.equal(res, 0.8151987636583022, res + ' != 0.8151987636583022');
+
+    inp['flueGasO2'] = 7.0;
+    res = bindings.flueGasLossesByMassGivenO2(inp);
+    t.equal(res, 0.7824331921965915, res + ' != 0.7824331921965915');
+});
+
 
 test('gasCoolingLosses', function (t) {
     t.plan(3);

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -81,6 +81,19 @@ test('flueGasByMass', function (t) {
     t.equal(res, 0.8222977480707968, res + ' != 0.8222977480707968');
 });
 
+test('flueGasByVolumeExcessAirConversion', function (t) {
+    t.plan(2);
+    t.type(bindings.flueGasLossesByVolumeExcessAirConversion, 'function');
+    var inp = {
+        flueGasTemperature: 700, excessAirPercentage: 0, combustionAirTemperature: 125, substance: 'test substance',
+        CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0,
+        O2: 3.0
+    };
+
+    var res = bindings.flueGasLossesByVolumeExcessAirConversion(inp);
+    t.equal(res, 0, res + ' != 0');
+});
+
 test('gasCoolingLosses', function (t) {
     t.plan(3);
     t.type(bindings.gasCoolingLosses, 'function');

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -82,7 +82,7 @@ test('flueGasByMass', function (t) {
 });
 
 test('flueGasLossesByVolumeGivenO2', function (t) {
-    t.plan(4);
+    t.plan(7);
     t.type(bindings.flueGasLossesByVolumeGivenO2, 'function');
     var inp = {
         flueGasTemperature: 700, flueGasO2: 0.5, combustionAirTemperature: 125, substance: 'test substance',
@@ -90,23 +90,23 @@ test('flueGasLossesByVolumeGivenO2', function (t) {
         O2: 0
     };
 
-    // GasCompositions composition("unit test gas", 94.1, 2.4, 1.41, 0.03, 0.49, 0.29, 0, 0.42, 0.71, 0, 0);
-    // REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition).getHeatLoss() == Approx(0.76899));
-
     var res = bindings.flueGasLossesByVolumeGivenO2(inp);
-    t.equal(res, 0.7758857340516403, res + ' != 0.7758857340516403');
+    t.equal(res['heatLoss'], 0.7758857340516403, res + ' != 0.7758857340516403');
+    t.equal(res['excessAir'], 2.3172209488353976, res + ' != 2.3172209488353976');
 
     inp['flueGasO2'] = 3.0;
     res = bindings.flueGasLossesByVolumeGivenO2(inp);
-    t.equal(res, 0.7622712144825897, res + ' != 0.7622712144825897');
+    t.equal(res['heatLoss'], 0.7622712144825897, res + ' != 0.7622712144825897');
+    t.equal(res['excessAir'], 15.52234414568954, res + ' != 15.52234414568954');
 
     inp['flueGasO2'] = 7.0;
     res = bindings.flueGasLossesByVolumeGivenO2(inp);
-    t.equal(res, 0.731683496609056, res + ' != 0.731683496609056');
+    t.equal(res['heatLoss'], 0.731683496609056, res + ' != 0.731683496609056');
+    t.equal(res['excessAir'], 45.197503654937584, res + ' != 45.197503654937584');
 });
 
 test('flueGasLossesByMassGivenO2', function (t) {
-    t.plan(4);
+    t.plan(7);
     t.type(bindings.flueGasLossesByMassGivenO2, 'function');
 
     var inp = {
@@ -116,15 +116,18 @@ test('flueGasLossesByMassGivenO2', function (t) {
     };
 
     var res = bindings.flueGasLossesByMassGivenO2(inp);
-    t.equal(res, 0.8297708723770466, res + ' != 0.8297708723770466');
+    t.equal(res['heatLoss'], 0.8297708723770466, res + ' != 0.8297708723770466');
+    t.equal(res['excessAir'], 2.29427816716376, res + ' != 2.29427816716376');
 
     inp['flueGasO2'] = 3.0;
     res = bindings.flueGasLossesByMassGivenO2(inp);
-    t.equal(res, 0.8151987636583022, res + ' != 0.8151987636583022');
+    t.equal(res['heatLoss'], 0.8151987636583022, res + ' != 0.8151987636583022');
+    t.equal(res['excessAir'], 15.368657569989644, res + ' != 15.368657569989644');
 
     inp['flueGasO2'] = 7.0;
     res = bindings.flueGasLossesByMassGivenO2(inp);
-    t.equal(res, 0.7824331921965915, res + ' != 0.7824331921965915');
+    t.equal(res['heatLoss'], 0.7824331921965915, res + ' != 0.7824331921965915');
+    t.equal(res['excessAir'], 44.75000361875009, res + ' != 44.75000361875009');
 });
 
 


### PR DESCRIPTION
Pull request overview
---------------------
Adds the ability to provide flue gas O2 levels as user input to the flue gas calculations. This input is then converted to excess air within an error range of 2% (this could be even more accurate if desired). Adds two NAN methods for each flue gas calculation - both for when the user provides flue gas O2 levels and doesn't provide excess air, so now there are four total NAN methods relating to flue gas calcs. Unit tests for the C++ and JavaScript were added and for both the excess air conversions and overall heatloss results and are producing equivalent numbers.