### PR TITLE
cleanup the pump head calculator

### DIFF
--- a/bindings/psat.h
+++ b/bindings/psat.h
@@ -32,6 +32,21 @@ using namespace v8;
 Local<Object> inp;
 Local<Object> r;
 
+double Get(const char *nm) {
+	Local<String> getName = Nan::New<String>(nm).ToLocalChecked();
+	auto rObj = inp->ToObject()->Get(getName);
+	if (rObj->IsUndefined()) {
+		assert(!"defined");
+	}
+	return rObj->NumberValue();
+}
+
+void SetR(const char *nm, double n) {
+	Local<String> getName = Nan::New<String>(nm).ToLocalChecked();
+	Local<Number> getNum = Nan::New<Number>(n);
+	Nan::Set(r, getName, getNum);
+}
+
 NAN_METHOD(headToolSuctionTank) {
     /**
     * Constructor for the HeadToolSuctionTank class with all inputs specified
@@ -49,38 +64,39 @@ NAN_METHOD(headToolSuctionTank) {
     *
  * */
 
-        const double specificGravity = info[0]->NumberValue();
-        const double flowRate = info[1]->NumberValue();
-        const double suctionPipeDiameter = info[2]->NumberValue();
-        const double suctionTankGasOverPressure = info[3]->NumberValue();
-        const double suctionTankFluidSurfaceElevation = info[4]->NumberValue();
-        const double suctionLineLossCoefficients = info[5]->NumberValue();
-        const double dischargePipeDiameter = info[6]->NumberValue();
-        const double dischargeGaugePressure = info[7]->NumberValue();
-        const double dischargeGaugeElevation = info[8]->NumberValue();
-        const double dischargeLineLossCoefficients = info[9]->NumberValue();
+    inp = info[0]->ToObject();
+    const double specificGravity = Get("specificGravity");
+    const double flowRate = Get("flowRate");
+    const double suctionPipeDiameter = Get("suctionPipeDiameter");
+    const double suctionTankGasOverPressure = Get("suctionTankGasOverPressure");
+    const double suctionTankFluidSurfaceElevation = Get("suctionTankFluidSurfaceElevation");
+    const double suctionLineLossCoefficients = Get("suctionLineLossCoefficients");
+    const double dischargePipeDiameter = Get("dischargePipeDiameter");
+    const double dischargeGaugePressure = Get("dischargeGaugePressure");
+    const double dischargeGaugeElevation = Get("dischargeGaugeElevation");
+    const double dischargeLineLossCoefficients = Get("dischargeLineLossCoefficients");
 
-        HeadToolSuctionTank htst(specificGravity, flowRate, suctionPipeDiameter, suctionTankGasOverPressure,
-                                 suctionTankFluidSurfaceElevation, suctionLineLossCoefficients, dischargePipeDiameter,
-                                 dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
+    HeadToolSuctionTank htst(specificGravity, flowRate, suctionPipeDiameter, suctionTankGasOverPressure,
+                             suctionTankFluidSurfaceElevation, suctionLineLossCoefficients, dischargePipeDiameter,
+                             dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
 
-        ReturnCalcValues retval = htst.calculate();
-        Local<String> differentialElevationHead = Nan::New<String>("differentialElevationHead").ToLocalChecked();
-        Local<String> differentialPressureHead = Nan::New<String>("differentialPressureHead").ToLocalChecked();
-        Local<String> differentialVelocityHead = Nan::New<String>("differentialVelocityHead").ToLocalChecked();
-        Local<String> estimatedSuctionFrictionHead = Nan::New<String>("estimatedSuctionFrictionHead").ToLocalChecked();
-        Local<String> estimatedDischargeFrictionHead = Nan::New<String>("estimatedDischargeFrictionHead").ToLocalChecked();
-        Local<String> pumpHead = Nan::New<String>("pumpHead").ToLocalChecked();
-        Local<Object> obj = Nan::New<Object>();
-        Nan::Set(obj, differentialElevationHead, Nan::New<Number>(retval.differentialElevationHead));
-        Nan::Set(obj, differentialPressureHead, Nan::New<Number>(retval.differentialPressureHead));
-        Nan::Set(obj, differentialVelocityHead, Nan::New<Number>(retval.differentialVelocityHead));
-        Nan::Set(obj, estimatedSuctionFrictionHead, Nan::New<Number>(retval.estimatedSuctionFrictionHead));
-        Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(retval.estimatedDischargeFrictionHead));
-        Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(retval.estimatedDischargeFrictionHead));
-        Nan::Set(obj, pumpHead, Nan::New<Number>(retval.pumpHead));
+    auto rv = htst.calculate();
+    Local<String> differentialElevationHead = Nan::New<String>("differentialElevationHead").ToLocalChecked();
+    Local<String> differentialPressureHead = Nan::New<String>("differentialPressureHead").ToLocalChecked();
+    Local<String> differentialVelocityHead = Nan::New<String>("differentialVelocityHead").ToLocalChecked();
+    Local<String> estimatedSuctionFrictionHead = Nan::New<String>("estimatedSuctionFrictionHead").ToLocalChecked();
+    Local<String> estimatedDischargeFrictionHead = Nan::New<String>("estimatedDischargeFrictionHead").ToLocalChecked();
+    Local<String> pumpHead = Nan::New<String>("pumpHead").ToLocalChecked();
+    Local<Object> obj = Nan::New<Object>();
+    Nan::Set(obj, differentialElevationHead, Nan::New<Number>(rv["differentialElevationHead"]));
+    Nan::Set(obj, differentialPressureHead, Nan::New<Number>(rv["differentialPressureHead"]));
+    Nan::Set(obj, differentialVelocityHead, Nan::New<Number>(rv["differentialVelocityHead"]));
+    Nan::Set(obj, estimatedSuctionFrictionHead, Nan::New<Number>(rv["estimatedSuctionFrictionHead"]));
+    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(rv["estimatedDischargeFrictionHead"]));
+    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(rv["estimatedDischargeFrictionHead"]));
+    Nan::Set(obj, pumpHead, Nan::New<Number>(rv["pumpHead"]));
 
-        info.GetReturnValue().Set(obj);
+    info.GetReturnValue().Set(obj);
 }
 
 NAN_METHOD(headTool) {
@@ -101,22 +117,23 @@ NAN_METHOD(headTool) {
     *
  * */
 
-        const double specificGravity = info[0]->NumberValue();
-        const double flowRate = info[1]->NumberValue();
-        const double suctionPipeDiameter = info[2]->NumberValue();
-        const double suctionGaugePressure = info[3]->NumberValue();
-        const double suctionGaugeElevation = info[4]->NumberValue();
-        const double suctionLineLossCoefficients = info[5]->NumberValue();
-        const double dischargePipeDiameter = info[6]->NumberValue();
-        const double dischargeGaugePressure = info[7]->NumberValue();
-        const double dischargeGaugeElevation = info[8]->NumberValue();
-        const double dischargeLineLossCoefficients = info[9]->NumberValue();
+    inp = info[0]->ToObject();
+    const double specificGravity = Get("specificGravity");
+    const double flowRate = Get("flowRate");
+    const double suctionPipeDiameter = Get("suctionPipeDiameter");
+    const double suctionGaugePressure = Get("suctionGaugePressure");
+    const double suctionGaugeElevation = Get("suctionGaugeElevation");
+    const double suctionLineLossCoefficients = Get("suctionLineLossCoefficients");
+    const double dischargePipeDiameter = Get("dischargePipeDiameter");
+    const double dischargeGaugePressure = Get("dischargeGaugePressure");
+    const double dischargeGaugeElevation = Get("dischargeGaugeElevation");
+    const double dischargeLineLossCoefficients = Get("dischargeLineLossCoefficients");
 
-        HeadTool ht(specificGravity, flowRate, suctionPipeDiameter, suctionGaugePressure,
-                    suctionGaugeElevation, suctionLineLossCoefficients, dischargePipeDiameter,
-                    dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
+    HeadTool ht(specificGravity, flowRate, suctionPipeDiameter, suctionGaugePressure,
+                suctionGaugeElevation, suctionLineLossCoefficients, dischargePipeDiameter,
+                dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
 
-        ReturnCalcValues retval = ht.calculate();
+    auto rv = ht.calculate();
     Local<String> differentialElevationHead = Nan::New<String>("differentialElevationHead").ToLocalChecked();
     Local<String> differentialPressureHead = Nan::New<String>("differentialPressureHead").ToLocalChecked();
     Local<String> differentialVelocityHead = Nan::New<String>("differentialVelocityHead").ToLocalChecked();
@@ -124,29 +141,14 @@ NAN_METHOD(headTool) {
     Local<String> estimatedDischargeFrictionHead = Nan::New<String>("estimatedDischargeFrictionHead").ToLocalChecked();
     Local<String> pumpHead = Nan::New<String>("pumpHead").ToLocalChecked();
     Local<Object> obj = Nan::New<Object>();
-    Nan::Set(obj, differentialElevationHead, Nan::New<Number>(retval.differentialElevationHead));
-    Nan::Set(obj, differentialPressureHead, Nan::New<Number>(retval.differentialPressureHead));
-    Nan::Set(obj, differentialVelocityHead, Nan::New<Number>(retval.differentialVelocityHead));
-    Nan::Set(obj, estimatedSuctionFrictionHead, Nan::New<Number>(retval.estimatedSuctionFrictionHead));
-    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(retval.estimatedDischargeFrictionHead));
-    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(retval.estimatedDischargeFrictionHead));
-    Nan::Set(obj, pumpHead, Nan::New<Number>(retval.pumpHead));
-        info.GetReturnValue().Set(obj);
-}
-
-double Get(const char *nm) {
-    Local<String> getName = Nan::New<String>(nm).ToLocalChecked();
-    auto rObj = inp->ToObject()->Get(getName);
-    if (rObj->IsUndefined()) {
-        assert(!"defined");
-    }
-    return rObj->NumberValue();
-}
-
-void SetR(const char *nm, double n) {
-    Local<String> getName = Nan::New<String>(nm).ToLocalChecked();
-    Local<Number> getNum = Nan::New<Number>(n);
-    Nan::Set(r, getName, getNum);
+    Nan::Set(obj, differentialElevationHead, Nan::New<Number>(rv["differentialElevationHead"]));
+    Nan::Set(obj, differentialPressureHead, Nan::New<Number>(rv["differentialPressureHead"]));
+    Nan::Set(obj, differentialVelocityHead, Nan::New<Number>(rv["differentialVelocityHead"]));
+    Nan::Set(obj, estimatedSuctionFrictionHead, Nan::New<Number>(rv["estimatedSuctionFrictionHead"]));
+    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(rv["estimatedDischargeFrictionHead"]));
+    Nan::Set(obj, estimatedDischargeFrictionHead, Nan::New<Number>(rv["estimatedDischargeFrictionHead"]));
+    Nan::Set(obj, pumpHead, Nan::New<Number>(rv["pumpHead"]));
+    info.GetReturnValue().Set(obj);
 }
 
 // Fields

--- a/include/calculator/pump/HeadTool.h
+++ b/include/calculator/pump/HeadTool.h
@@ -10,63 +10,13 @@
 #ifndef AMO_TOOLS_SUITE_HEADTOOL_H
 #define AMO_TOOLS_SUITE_HEADTOOL_H
 
-/**
-* Used to return the calculation made in both HeadTool classes, should not be used otherwise
-* */
-class ReturnCalcValues {
-public:
-	/**
-    * Constructor for the ReturnCalcValues class with all inputs specified
-    *
-    * @param differentialElevationHead double, differential elevation head in ft
-    * @param differentialPressureHead double, differential pressure head in ft
-    * @param differentialVelocityHead double, differential velocity head in ft
-    * @param estimatedSuctionFrictionHead double, estimated suction friction head in ft
-    * @param estimatedDischargeFrictionHead double, estimated discharge friction head in ft
-    * @param pumpHead double, pump head in ft
-    *
-    * @return nothing
-	*
- * */
-	ReturnCalcValues(
-			const double differentialElevationHead,
-			const double differentialPressureHead,
-			const double differentialVelocityHead,
-			const double estimatedSuctionFrictionHead,
-			const double estimatedDischargeFrictionHead,
-			const double pumpHead
-	) :
-			differentialElevationHead(differentialElevationHead),
-			differentialPressureHead(differentialPressureHead),
-			differentialVelocityHead(differentialVelocityHead),
-			estimatedSuctionFrictionHead(estimatedSuctionFrictionHead),
-			estimatedDischargeFrictionHead(estimatedDischargeFrictionHead),
-			pumpHead(pumpHead)
-	{}
-
-	///units of ft
-	const double differentialElevationHead;
-
-	///units of ft
-	const double differentialPressureHead;
-
-	///units of ft
-	const double differentialVelocityHead;
-
-    ///units of ft
-	const double estimatedSuctionFrictionHead;
-
-	///units of ft
-	const double estimatedDischargeFrictionHead;
-
-	///units of ft
-	const double pumpHead;
-};
+#include <string>
+#include <unordered_map>
 
 /**
  * Head Tool Base class
  * Contains all of the basic properties of a head tool.
- * Used to calculate velocity and velocity head so those values can be used in the HeadToolSuctionTank class or HeadTool class to calculate all of the values in the ReturnCalcValues class.
+ * Used to calculate velocity and velocity head so those values can be used in the HeadToolSuctionTank class or HeadTool class to calculate all of the values in the returned map.
  */
 class HeadToolBase {
 protected:
@@ -107,9 +57,9 @@ protected:
 	/**
      * Calculates the operating pump head
      *
-     * @return ReturnCalcValues class with all its values calculated
+     * @return unordered map with all its values calculated
      */
-	virtual ReturnCalcValues calculate() = 0;
+	virtual std::unordered_map<std::string, double> calculate() = 0;
 
 	/**
      * Calculates the velocity
@@ -156,7 +106,7 @@ protected:
 /**
  * Head Tool Suction Tank class
  * Contains all of the properties of a head tool suction tank.
- * Used to calculate all of the values in the ReturnCalcValues class.
+ * Used to calculate all of the values in the returned map.
  */
 class HeadToolSuctionTank : private HeadToolBase {
 public:
@@ -204,9 +154,9 @@ public:
 	/**
      * Calculates the operating pump head
      *
-     * @return ReturnCalcValues, all the values calculated for operating pump head
+     * @return unordered map with all the values calculated for operating pump head
      */
-	ReturnCalcValues calculate();
+	std::unordered_map<std::string, double> calculate() override;
 
 private:
 	const double suctionTankGasOverPressure_, suctionTankFluidSurfaceElevation_;
@@ -215,7 +165,7 @@ private:
 /**
  * Head Tool class
  * Contains all of the properties of a head tool.
- * Used to calculate all of the values of the ReturnCalcValues class.
+ * Used to calculate all of the values of the returned unordered map.
  */
 class HeadTool : private HeadToolBase {
 public:
@@ -262,9 +212,9 @@ public:
 /**
      * Calculates the operating pump head
      *
-     * @return ReturnCalcValues class with internal values calculated
+     * @return unordered_map with internal values calculated
      */
-	ReturnCalcValues calculate();
+	std::unordered_map<std::string, double> calculate() override;
 
 private:
 	const double suctionGaugePressure_, suctionGaugeElevation_;

--- a/src/calculator/pump/HeadTool.cpp
+++ b/src/calculator/pump/HeadTool.cpp
@@ -17,7 +17,7 @@ double HeadToolBase::velocityHead(const double velocity, const double gravity) {
 	return ( ( velocity * velocity ) / 2.0 )  / gravity;
 }
 
-ReturnCalcValues HeadToolSuctionTank::calculate() {
+std::unordered_map<std::string, double> HeadToolSuctionTank::calculate() {
 	// this flow and pressure head should be used when units are metric, and the number 12 should be replaced with 1000
 	// in the velocityHead Suction and Discharge calculations
 //	const double flow = flowRate_ * 4.402867544 / 15850.32316;
@@ -35,12 +35,19 @@ ReturnCalcValues HeadToolSuctionTank::calculate() {
 	const double suctionHead = suctionLineLossCoefficients_ * velocityHeadSuction;
 	const double dischargeHead = dischargeLineLossCoefficients_ * velocityHeadDischarge;
 
-	const double head = elevationHead + pressureHead + velocityHeadDifferential + suctionHead + dischargeHead;
+	const double pumpHead = elevationHead + pressureHead + velocityHeadDifferential + suctionHead + dischargeHead;
 
-	return ReturnCalcValues(elevationHead, pressureHead, velocityHeadDifferential, suctionHead, dischargeHead, head);
+	return {
+			{"elevationHead",            elevationHead},
+			{"pressureHead",             pressureHead},
+			{"velocityHeadDifferential", velocityHeadDifferential},
+			{"suctionHead",              suctionHead},
+			{"dischargeHead",            dischargeHead},
+			{"pumpHead",                 pumpHead}
+	};
 }
 
-ReturnCalcValues HeadTool::calculate() {
+std::unordered_map<std::string, double> HeadTool::calculate() {
 //	const double flow = flowRate_ * 4.402867544 / 15850.32316;
 //	const double pressureHead =
 //			(((dischargeGaugePressure_ - suctionGaugePressure_) * 0.145037738007) / 1.42197020632) / specificGravity_;
@@ -56,8 +63,15 @@ ReturnCalcValues HeadTool::calculate() {
 	const double suctionHead = suctionLineLossCoefficients_ * velocityHeadSuction;
 	const double dischargeHead = dischargeLineLossCoefficients_ * velocityHeadDischarge;
 
-	const double head = elevationHead + pressureHead + velocityHeadDifferential + suctionHead + dischargeHead;
+	const double pumpHead = elevationHead + pressureHead + velocityHeadDifferential + suctionHead + dischargeHead;
 
-	return ReturnCalcValues(elevationHead, pressureHead, velocityHeadDifferential, suctionHead, dischargeHead, head);
+	return {
+			{"elevationHead",            elevationHead},
+			{"pressureHead",             pressureHead},
+			{"velocityHeadDifferential", velocityHeadDifferential},
+			{"suctionHead",              suctionHead},
+			{"dischargeHead",            dischargeHead},
+			{"pumpHead",                 pumpHead}
+	};
 }
 

--- a/tests/HeadTool.unit.cpp
+++ b/tests/HeadTool.unit.cpp
@@ -3,28 +3,28 @@
 
 TEST_CASE( "Calculate Pump Head with and without suction tanks", "[HeadToolCalculations]" ) {
 	const double flowRate = 2000;
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 115, 0, 1, 10, 124, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 115, 0, 1, 10, 124, 0, 1).calculate()["pumpHead"] ==
 	        Approx(22.972865551821844));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 0, 1, 10, 124, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 0, 1, 10, 124, 0, 1).calculate()["pumpHead"] ==
 	        Approx(46.080895538862784));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 10, 124, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 10, 124, 0, 1).calculate()["pumpHead"] ==
 	        Approx(41.080895538862784));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 0.5, 10, 124, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 0.5, 10, 124, 0, 1).calculate()["pumpHead"] ==
 	        Approx(41.03037569241383));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 124, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 124, 0, 1).calculate()["pumpHead"] ==
 	        Approx(39.41609397604601));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 135, 0, 1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 135, 0, 1).calculate()["pumpHead"] ==
 	        Approx(64.83492696179103));
-	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 135, 4, 0.1).calculate().pumpHead ==
+	REQUIRE(HeadToolSuctionTank(1, flowRate, 17.9, 105, 5, 1, 15, 135, 4, 0.1).calculate()["pumpHead"] ==
 	        Approx(68.6505181732944));
 
 
-	REQUIRE( HeadTool(1, flowRate, 17.9, 5, 5, 1, 15, 50, 1, 1 ).calculate().pumpHead == Approx(100.39593224945455) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 5, 1, 15, 50, 1, 1 ).calculate().pumpHead == Approx(88.84191725593406) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 1, 15, 50, 1, 1 ).calculate().pumpHead == Approx(78.84191725593406) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 15, 50, 1, 1 ).calculate().pumpHead == Approx(78.75098153232594) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 50, 1, 1 ).calculate().pumpHead == Approx(78.34278499528914) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 1, 1 ).calculate().pumpHead == Approx(9.018695034166301) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 10, 1 ).calculate().pumpHead == Approx(18.0186950341663) );
-	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 10, 0.9 ).calculate().pumpHead == Approx(18.018614995629626) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 5, 5, 1, 15, 50, 1, 1 ).calculate()["pumpHead"] == Approx(100.39593224945455) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 5, 1, 15, 50, 1, 1 ).calculate()["pumpHead"] == Approx(88.84191725593406) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 1, 15, 50, 1, 1 ).calculate()["pumpHead"] == Approx(78.84191725593406) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 15, 50, 1, 1 ).calculate()["pumpHead"] == Approx(78.75098153232594) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 50, 1, 1 ).calculate()["pumpHead"] == Approx(78.34278499528914) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 1, 1 ).calculate()["pumpHead"] == Approx(9.018695034166301) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 10, 1 ).calculate()["pumpHead"] == Approx(18.0186950341663) );
+	REQUIRE( HeadTool(1, flowRate, 17.9, 10, 15, 0.1, 60, 20, 10, 0.9 ).calculate()["pumpHead"] == Approx(18.018614995629626) );
 }


### PR DESCRIPTION
This cleans up the pump head calculator to be more easily understandable and maintainable code. I originally wrote this and now realize that making use of the C++ standard library unordered_map is better than having a separate class to return groups of values. 

