### PR TITLE
fix issue related to issue 635 in the desktop

### DIFF
--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -173,8 +173,9 @@ NAN_METHOD(gasCoolingLosses) {
   * @return heatLoss double
   * */
     inp = info[0]->ToObject();
-    GasCoolingLosses gcl(Get("flowRate"), Get("initialTemperature"), Get("finalTemperature"), Get("specificHeat"), Get("correctionFactor"));
-    double heatLoss = gcl.getHeatLoss();
+    GasCoolingLosses gcl(Get("flowRate"), Get("initialTemperature"), Get("finalTemperature"), Get("specificHeat"),
+                         Get("correctionFactor"), Get("gasDensity"));
+    const double heatLoss = gcl.getHeatLoss();
     Local<Number> retval = Nan::New(heatLoss);
     info.GetReturnValue().Set(retval);
 }

--- a/include/calculator/losses/GasCoolingLosses.h
+++ b/include/calculator/losses/GasCoolingLosses.h
@@ -32,136 +32,23 @@ public:
      * */
 
 
-    GasCoolingLosses(double flowRate,
-                     double initialTemperature,
-                     double finalTemperature,
-                     double specificHeat,
-                     double correctionFactor)
+    GasCoolingLosses(const double flowRate, const double initialTemperature, const double finalTemperature,
+                     const double specificHeat, const double correctionFactor, const double gasDensity)
             : flowRate_(flowRate),
               initialTemperature_(initialTemperature),
               finalTemperature_(finalTemperature),
               specificHeat_(specificHeat),
-              correctionFactor_(correctionFactor)
-    {
-        heatLoss_ = 0.0;
-    }
-
-    GasCoolingLosses() = default;
-
-    /**
-     * Gets the air or gas volumetric flow rate
-     *
-     * @return double, flow rate in scfm
-     */
-    double getFlowRate() const {
-        return flowRate_;
-    }
-
-    /**
-     * Sets the air or gas volumetric flow rate
-     *
-     * @param flowRate double, flow rate in scfm
-     *
-     * @return nothing
-     */
-    void setFlowRate(double flowRate) {
-        flowRate_ = flowRate;
-    }
-
-    /**
-     * Gets the initial temperature
-     *
-     * @return double, initial temperature in °F
-     */
-    double getInitialTemperature() const {
-        return initialTemperature_;
-    }
-
-    /**
-     * Sets the initial temperature
-     *
-     * @param initialTemperature double, initial temperature in °F
-     *
-     * @return nothing
-     */
-    void setInitialTemperature(double initialTemperature) {
-        initialTemperature_ = initialTemperature;
-    }
-
-    /**
-     * Gets the final temperature
-     *
-     * @return double, final temeprature in °F
-     */
-    double getFinalTemperature() const {
-        return finalTemperature_;
-    }
-
-    /**
-     * Sets the final temperature
-     *
-     * @param finalTemperature double, final temperature in °F
-     *
-     * @return nothing
-     */
-    void setFinalTemperature(double finalTemperature) {
-        finalTemperature_ = finalTemperature;
-    }
-
-    /**
-     * Gets the specific heat of air or gas at average air temperature
-     *
-     * @return double, specific heat of air or gas in btu/(scf*°F)
-     */
-    double getSpecificHeat() const {
-        return specificHeat_;
-    }
-
-    /**
-     * Sets the specific heat of air or gas at average air temperature
-     *
-     * @param specificHeat double, specific heat of air or gas in btu/(scf*°F)
-     *
-     * @return nothing
-     */
-    void setSpecificHeat(double specificHeat) {
-        specificHeat_ = specificHeat;
-    }
-
-    /**
-     * Gets the correction factor
-     *
-     * @return double, correction factor - unitless
-     */
-    double getCorrectionFactor() const {
-        return correctionFactor_;
-    }
-
-    /**
-     * Sets the correction factor
-     *
-     * @param correctionFactor double, correction factor - unitless
-     *
-     * @return nothing
-     */
-    void setCorrectionFactor(double correctionFactor) {
-        correctionFactor_ = correctionFactor;
-    }
+              correctionFactor_(correctionFactor),
+              gasDensity_(gasDensity) {}
 
     /**
      * Gets the total heat loss
      *
      * @return double, heat loss in btu/hr
      */
-    double getHeatLoss();
+    double getHeatLoss() const;
 
 private:
-    // In values
-    double flowRate_;
-    double initialTemperature_;
-    double finalTemperature_;
-    double specificHeat_;
-    double correctionFactor_;
-    double heatLoss_;
+    const double flowRate_, initialTemperature_, finalTemperature_, specificHeat_, correctionFactor_, gasDensity_;
 };
 #endif //AMO_SUITE_GASCOOLINGLOSSES_H

--- a/src/calculator/losses/GasCoolingLosses.cpp
+++ b/src/calculator/losses/GasCoolingLosses.cpp
@@ -8,8 +8,6 @@
  */
 #include "calculator/losses/GasCoolingLosses.h"
 
-double GasCoolingLosses::getHeatLoss() {
-// return the heat loss for the air test case
-    this->heatLoss_ = (this->flowRate_ * 60.0) * this->specificHeat_ * (this->finalTemperature_ - this->initialTemperature_) * this->correctionFactor_;
-    return this->heatLoss_;
+double GasCoolingLosses::getHeatLoss() const {
+    return flowRate_ * 60.0 * gasDensity_ * specificHeat_ * (finalTemperature_ - initialTemperature_) * correctionFactor_;
 }

--- a/tests/GasCoolingLosses.unit.cpp
+++ b/tests/GasCoolingLosses.unit.cpp
@@ -2,8 +2,6 @@
 #include <calculator/losses/GasCoolingLosses.h>
 
 TEST_CASE( "Calculate Heat Loss for gas cooling Losses Air", "[Heat Loss]" ) {
-
-    REQUIRE(GasCoolingLosses(2500.0, 80.0, 280.0, 0.02, 1.0).getHeatLoss() == Approx(600000.0 ) );
-    REQUIRE(GasCoolingLosses(600, 80.0, 350.0, 0.02, 1.0).getHeatLoss() == Approx(194400.0 ) );
-
+    REQUIRE(GasCoolingLosses(2500.0, 80.0, 280.0, 0.02, 1.0, 1).getHeatLoss() == Approx(600000.0));
+    REQUIRE(GasCoolingLosses(600, 80.0, 350.0, 0.02, 1.0, 1).getHeatLoss() == Approx(194400.0));
 }

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -140,7 +140,8 @@ test('gasCoolingLosses', function (t) {
     t.type(bindings.gasCoolingLosses, 'function');
 
     var inp = {
-        flowRate: 2500, initialTemperature: 80, finalTemperature: 280, specificHeat: 0.02, correctionFactor: 1.0
+        flowRate: 2500, initialTemperature: 80, finalTemperature: 280, specificHeat: 0.02, correctionFactor: 1.0,
+        gasDensity: 1
     };
 
     var res = bindings.gasCoolingLosses(inp);


### PR DESCRIPTION
https://github.com/ORNL-AMO/AMO-Tools-Desktop/issues/635

fixes the GasCoolingLosses heatLoss calculation not accounting for gasses of different densities. 
