### PR TITLE
Add fuelTemperature to GasFlueGas input

### DIFF
--- a/bindings/phast.h
+++ b/bindings/phast.h
@@ -498,7 +498,8 @@ NAN_METHOD(flueGasLossesByVolume) {
 	GasCompositions comps("substance", Get("CH4"), Get("C2H6"), Get("N2"), Get("H2"), Get("C3H8"),
 	                      Get("C4H10_CnH2n"), Get("H2O"), Get("CO"), Get("CO2"), Get("SO2"), Get("O2"));
 
-	GasFlueGasMaterial fg(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"), comps);
+	GasFlueGasMaterial fg(Get("flueGasTemperature"), Get("excessAirPercentage"), Get("combustionAirTemperature"),
+                          comps, Get("fuelTemperature"));
 
 	double heatLoss = fg.getHeatLoss();
 	Local<Number> retval = Nan::New(heatLoss);
@@ -574,7 +575,7 @@ NAN_METHOD(flueGasLossesByVolumeGivenO2) {
     auto const flueGasO2 = Get("flueGasO2") / 100.0;
     auto const excessAir = comp.calculateExcessAir(flueGasO2);
 
-    GasFlueGasMaterial fg(Get("flueGasTemperature"), excessAir * 100.0, Get("combustionAirTemperature"), comp);
+    GasFlueGasMaterial fg(Get("flueGasTemperature"), excessAir * 100.0, Get("combustionAirTemperature"), comp, Get("fuelTemperature"));
     double heatLoss = fg.getHeatLoss();
 
     r = Nan::New<Object>();

--- a/include/calculator/losses/GasFlueGasMaterial.h
+++ b/include/calculator/losses/GasFlueGasMaterial.h
@@ -249,14 +249,16 @@ public:
      * @param excessAirPercentage double, Percent Excess Air, expressed in normal percentage (i.e. 9% as 9 instead of 0.09)
      * @param combustionAirTemperature double, Combustion Air Temperature in °F
      * @param compositions - GasComposition, User defined gas compositions
+     * @param fuelTemperature double - temperature of fuel
      * @return nothing
      *
      * */
     GasFlueGasMaterial(const double flueGasTemperature, const double excessAirPercentage,
-                       const double combustionAirTemperature,
-                       GasCompositions compositions) :
-		    flueGasTemperature_(flueGasTemperature), excessAirPercentage_(excessAirPercentage / 100.0),
-            combustionAirTemperature_(combustionAirTemperature), compositions_(std::move(compositions))
+                       const double combustionAirTemperature, GasCompositions compositions,
+                       const double fuelTemperature) :
+		    flueGasTemperature(flueGasTemperature), excessAirPercentage(excessAirPercentage / 100.0),
+            combustionAirTemperature(combustionAirTemperature), fuelTemperature(fuelTemperature),
+		    compositions(std::move(compositions))
     {}
 
 	/**
@@ -267,7 +269,7 @@ public:
     double getHeatLoss();
 
 private:
-    const double flueGasTemperature_, excessAirPercentage_, combustionAirTemperature_;
-	GasCompositions compositions_;
+    const double flueGasTemperature, excessAirPercentage, combustionAirTemperature, fuelTemperature;
+	GasCompositions compositions;
 };
 #endif //AMO_SUITE_GASFLUEGASMATERIAL_H

--- a/src/calculator/losses/GasFlueGasMaterial.cpp
+++ b/src/calculator/losses/GasFlueGasMaterial.cpp
@@ -44,13 +44,13 @@ void GasCompositions::calculateCompByWeight() {
     }
 }
 
-double GasCompositions::calculateSensibleHeat(const double combustionAirTemp) {
+double GasCompositions::calculateSensibleHeat(const double fuelTemp) {
     double specificHeatFuel = 0;
     for ( auto const & comp : gasses ) {
         specificHeatFuel += comp.second->compByWeight * (comp.second->specificHeat(520) / comp.second->molecularWeight);
     }
 
-    return 1 * specificHeatFuel * (combustionAirTemp - 32);
+    return 1 * specificHeatFuel * (fuelTemp - 32);
 }
 
 double GasCompositions::calculateHeatCombustionAir(const double combustionAirTemp, const double excessAir) {
@@ -153,15 +153,15 @@ double GasCompositions::calculateTotalHeatContentFlueGas(const double flueGasTem
 }
 
 double GasFlueGasMaterial::getHeatLoss() {
-	compositions_.calculateCompByWeight();
-    double heatInFlueGasses = compositions_.calculateSensibleHeat(combustionAirTemperature_);
-    double hCombustionAir = compositions_.calculateHeatCombustionAir(combustionAirTemperature_, excessAirPercentage_);
-    double hValueFuel = compositions_.calculateHeatingValueFuel();
-    compositions_.calculateMassFlueGasComponents(excessAirPercentage_);
-    compositions_.calculateEnthalpy();
-    double totalHeatContentFlueGas = compositions_.calculateTotalHeatContentFlueGas(flueGasTemperature_);
+	compositions.calculateCompByWeight();
+    const double heatInFlueGasses = compositions.calculateSensibleHeat(fuelTemperature);
+    const double hCombustionAir = compositions.calculateHeatCombustionAir(combustionAirTemperature, excessAirPercentage);
+    const double hValueFuel = compositions.calculateHeatingValueFuel();
+    compositions.calculateMassFlueGasComponents(excessAirPercentage);
+    compositions.calculateEnthalpy();
+    const double totalHeatContentFlueGas = compositions.calculateTotalHeatContentFlueGas(flueGasTemperature);
 
-    double heatInput = heatInFlueGasses + hCombustionAir + hValueFuel;
+    const double heatInput = heatInFlueGasses + hCombustionAir + hValueFuel;
 
     return (heatInput - totalHeatContentFlueGas) / hValueFuel;
 }

--- a/tests/GasFlueGasMaterial.unit.cpp
+++ b/tests/GasFlueGasMaterial.unit.cpp
@@ -8,10 +8,10 @@ TEST_CASE( "Calculate Heat Loss for flue gas Losses", "[Heat Loss]" ) {
 	REQUIRE(composition.calculateExcessAir(0.03) == Approx(0.1552234));
 	REQUIRE(composition.calculateExcessAir(0.07) == Approx(0.451975));
 
-	REQUIRE(GasFlueGasMaterial(700, 2.31722095, 125, composition).getHeatLoss() == Approx(0.7758857341));
-	REQUIRE(GasFlueGasMaterial(700, 15.52234415, 125, composition).getHeatLoss() == Approx(0.7622712145));
-	REQUIRE(GasFlueGasMaterial(700, 45.19750365, 125, composition).getHeatLoss() == Approx(0.7316834966));
-	REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition).getHeatLoss() == Approx(0.76899));
+	REQUIRE(GasFlueGasMaterial(700, 2.31722095, 125, composition, 125).getHeatLoss() == Approx(0.7758857341));
+	REQUIRE(GasFlueGasMaterial(700, 15.52234415, 125, composition, 125).getHeatLoss() == Approx(0.7622712145));
+	REQUIRE(GasFlueGasMaterial(700, 45.19750365, 125, composition, 125).getHeatLoss() == Approx(0.7316834966));
+	REQUIRE(GasFlueGasMaterial(700, 9.0, 125, composition, 125).getHeatLoss() == Approx(0.76899));
 
 
 	composition = GasCompositions("Typical Natural Gas - US", 87, 8.5, 3.6, 0.4, 0, 0, 0, 0, 0.4, 0, 0.1);

--- a/tests/js/lossesTest.js
+++ b/tests/js/lossesTest.js
@@ -62,9 +62,9 @@ test('flueGasByVolume', function (t) {
     t.plan(5);
     t.type(bindings.flueGasLossesByVolume, 'function');
     var inp = {
-        flueGasTemperature: 700, excessAirPercentage: 9.0, combustionAirTemperature: 125, substance: 'test substance',
-        CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0,
-        O2: 0
+        flueGasTemperature: 700, excessAirPercentage: 9.0, combustionAirTemperature: 125, fuelTemperature: 125,
+        substance: 'test substance', CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29,
+        H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0, O2: 0
     };
 
     var res = bindings.flueGasLossesByVolume(inp);
@@ -77,7 +77,7 @@ test('flueGasByVolume', function (t) {
     };
 
     t.type(bindings.flueGasByVolumeCalculateHeatingValue, 'function');
-    res = bindings.flueGasByVolumeCalculateHeatingValue(inp)
+    res = bindings.flueGasByVolumeCalculateHeatingValue(inp);
     t.equal(rnd(res.heatingValue), rnd(22630.355481));
     t.equal(rnd(res.specificGravity), rnd(0.631783));
 });
@@ -111,8 +111,8 @@ test('flueGasLossesByVolumeGivenO2', function (t) {
     t.type(bindings.flueGasLossesByVolumeGivenO2, 'function');
     var inp = {
         flueGasTemperature: 700, flueGasO2: 0.5, combustionAirTemperature: 125, substance: 'test substance',
-        CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42, CO2: 0.71, SO2: 0,
-        O2: 0
+        fuelTemperature: 125, CH4: 94.1, C2H6: 2.4, N2: 1.41, H2: 0.03, C3H8: 0.49, C4H10_CnH2n: 0.29, H2O: 0, CO: 0.42,
+        CO2: 0.71, SO2: 0, O2: 0
     };
 
     var res = bindings.flueGasLossesByVolumeGivenO2(inp);


### PR DESCRIPTION
Fixes an oversight of not having fuelTemperature as an input to flue gas by volume calculations. This introduces changes to the associated bindings `flueGasLossesByVolume` and `flueGasLossesByVolumeGivenO2` - they now need an extra field `fuelTemperature`

connect #145 