### PR TITLE
Update fan bindings

### DIFF
--- a/bindings/fan.h
+++ b/bindings/fan.h
@@ -38,10 +38,6 @@ std::string GetStr(std::string const & key, Local<Object> obj) {
 	return std::string(*s);
 }
 
-bool isUndefined(Local<Object> obj, std::string const & key) {
-	return obj->Get(Nan::New<String>(key).ToLocalChecked())->IsUndefined();
-}
-
 bool isDefined(Local<Object> obj, std::string const & key) {
 	return !obj->Get(Nan::New<String>(key).ToLocalChecked())->IsUndefined();
 }
@@ -67,27 +63,15 @@ std::vector <std::vector<double>> getTraverseInputData(Local<Object> obj) {
 }
 
 template <class Plane> Plane construct(Local<Object> obj) {
-	if (isUndefined(obj, "circularDuctDiameter")) {
-		auto const noInletBoxes = (isUndefined(obj, "noInletBoxes")) ? 1 : static_cast<unsigned>(Get("noInletBoxes", obj));
-		return {Get("length", obj), Get("width", obj), Get("tdx", obj), Get("pbx", obj), noInletBoxes};
-	}
-	return {Get("circularDuctDiameter", obj), Get("tdx", obj), Get("pbx", obj)};
+	return {Get("area", obj), Get("tdx", obj), Get("pbx", obj)};
 }
 
 template <class Plane> Plane constructMst(Local<Object> obj) {
-	if (isUndefined(obj, "circularDuctDiameter")) {
-		auto const noInletBoxes = (isUndefined(obj, "noInletBoxes")) ? 1 : static_cast<unsigned>(Get("noInletBoxes", obj));
-		return {Get("length", obj), Get("width", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj), noInletBoxes};
-	}
-	return {Get("circularDuctDiameter", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj)};
+	return {Get("area", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj)};
 }
 
 template <class Plane> Plane constructTraverse(Local<Object> obj) {
-	if (isUndefined(obj, "circularDuctDiameter")) {
-		unsigned const noInletBoxes = (isUndefined(obj, "noInletBoxes")) ? 1 : static_cast<unsigned>(Get("noInletBoxes", obj));
-		return {Get("length", obj), Get("width", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj), Get("pitotTubeCoefficient", obj), getTraverseInputData(obj), noInletBoxes};
-	}
-	return {Get("circularDuctDiameter", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj), Get("pitotTubeCoefficient", obj), getTraverseInputData(obj)};
+	return {Get("area", obj), Get("tdx", obj), Get("pbx", obj), Get("psx", obj), Get("pitotTubeCoefficient", obj), getTraverseInputData(obj)};
 }
 
 FanRatedInfo getFanRatedInfo() {
@@ -178,15 +162,15 @@ NAN_METHOD(fan203) {
 	r = Nan::New<Object>();
 	try {
 		auto const rv = Fan(getFanRatedInfo(), getPlaneData(), getBaseGasDensity(), getFanShaftPower()).calculate();
-		SetR("fanEfficiencyTp", rv.at("fanEfficiencyTp"));
-		SetR("fanEfficiencySp", rv.at("fanEfficiencySp"));
-		SetR("fanEfficiencySpr", rv.at("fanEfficiencySpr"));
-		SetR("Qc", rv.at("Qc"));
-		SetR("Ptc", rv.at("Ptc"));
-		SetR("Psc", rv.at("Psc"));
-		SetR("SPRc", rv.at("SPRc"));
-		SetR("Hc", rv.at("Hc"));
-		SetR("Kpc", rv.at("Kpc"));
+		SetR("fanEfficiencyTotalPressure", rv.fanEfficiencyTotalPressure);
+		SetR("fanEfficiencyStaticPressure", rv.fanEfficiencyStaticPressure);
+		SetR("fanEfficiencyStaticPressureRise", rv.fanEfficiencyStaticPressureRise);
+		SetR("flowCorrected", rv.flowCorrected);
+		SetR("pressureTotalCorrected", rv.pressureTotalCorrected);
+		SetR("pressureStaticCorrected", rv.pressureStaticCorrected);
+		SetR("staticPressureRiseCorrected", rv.staticPressureRiseCorrected);
+		SetR("powerCorrected", rv.powerCorrected);
+		SetR("kpc", rv.kpc);
 	} catch (std::runtime_error const & e) {
 		std::string const what = e.what();
 		ThrowError(std::string("std::runtime_error thrown in fan203 - fan.h: " + what).c_str());

--- a/include/fans/Fan.h
+++ b/include/fans/Fan.h
@@ -258,7 +258,7 @@ public:
 		auto const x = (planeData.fanOrEvaseOutletFlange.gasTotalPressure - planeData.fanInletFlange.gasTotalPressure)
 		               / (planeData.fanInletFlange.gasTotalPressure + 13.63 * planeData.fanInletFlange.barometricPressure);
 
-		double isentropicExponent = 0; // TODO what value to use for GasTypes other than Air ?
+		double isentropicExponent = 1.4; // TODO what value to use for GasTypes other than Air ?
 		if (baseGasDensity.gasType == BaseGasDensity::GasType::AIR) isentropicExponent = 1.4;
 
 		// TODO barometricPressure = barometric pressure, what to do if barometric pressure does vary between planes ? pg 61

--- a/include/fans/Planar.h
+++ b/include/fans/Planar.h
@@ -20,14 +20,11 @@ protected:
 
 class Planar {
 protected:
-	Planar(double circularDuctDiameter, double tdx, double pbx, double psx);
+	Planar(double area, double tdx, double pbx, double psx);
 
-	Planar(double length, double width, double tdx, double pbx, double psx, unsigned noInletBoxes = 1);
-
-//	where tdx = dryBulbTemperature and pbx = barometric pressure
-	const double tdx, pbx, area;
+	const double dryBulbTemperature, barometricPressure, area;
 	double gasDensity = 0, gasVelocity = 0, gasVolumeFlowRate = 0, gasVelocityPressure = 0, gasTotalPressure = 0;
-	double psx = 0;
+	double staticPressure = 0;
 
 	friend class PlaneData;
 	friend class Fan;
@@ -35,49 +32,35 @@ protected:
 
 class FanInletFlange : public Planar {
 public:
-	FanInletFlange(double circularDuctDiameter, double tdx, double pbx);
-
-	FanInletFlange(double length, double width, double tdx, double pbx, unsigned noInletBoxes = 1);
+	FanInletFlange(double area, double tdx, double pbx);
 };
 
 class FanOrEvaseOutletFlange : public Planar {
 public:
-	FanOrEvaseOutletFlange(double circularDuctDiameter, double tdx, double pbx);
-
-	FanOrEvaseOutletFlange(double length, double width, double tdx, double pbx, unsigned noInletBoxes = 1);
+	FanOrEvaseOutletFlange(double area, double tdx, double pbx);
 };
 
 
 class FlowTraverse : public Planar, public VelocityPressureTraverseData {
 public:
-	FlowTraverse(double circularDuctDiameter, double tdx, double pbx,
-	             double psx, double pitotTubeCoefficient, std::vector< std::vector< double > > traverseHoleData);
-
-	FlowTraverse(double length, double width, double tdx, double pbx, double psx, double pitotTubeCoefficient,
-	             std::vector< std::vector< double > > traverseHoleData, unsigned noInletBoxes = 1);
+	FlowTraverse(double area, double tdx, double pbx, double psx, double pitotTubeCoefficient,
+	             std::vector< std::vector< double > > traverseHoleData);
 };
 
 class AddlTravPlane : public Planar, public VelocityPressureTraverseData {
 public:
-	AddlTravPlane(double circularDuctDiameter, double tdx, double pbx,
-	              double psx, double pitotTubeCoefficient, std::vector< std::vector< double > > traverseHoleData);
-
-	AddlTravPlane(double length, double width, double tdx, double pbx, double psx, double pitotTubeCoefficient,
-	              std::vector< std::vector< double > > traverseHoleData, unsigned noInletBoxes = 1);
+	AddlTravPlane(double area, double tdx, double pbx, double psx, double pitotTubeCoefficient,
+	              std::vector< std::vector< double > > traverseHoleData);
 };
 
 class InletMstPlane : public Planar {
 public:
-	InletMstPlane(double circularDuctDiameter, double tdx, double pbx, double psx);
-
-	InletMstPlane(double length, double width, double tdx, double pbx, double psx, unsigned noInletBoxes = 1);
+	InletMstPlane(double area, double tdx, double pbx, double psx);
 };
 
 class OutletMstPlane : public Planar {
 public:
-	OutletMstPlane(double circularDuctDiameter, double tdx, double pbx, double psx);
-
-	OutletMstPlane(double length, double width, double tdx, double pbx, double psx, unsigned noInletBoxes = 1);
+	OutletMstPlane(double area, double tdx, double pbx, double psx);
 };
 
 #endif //AMO_TOOLS_SUITE_PLANAR_H

--- a/src/fans/Planar.cpp
+++ b/src/fans/Planar.cpp
@@ -1,75 +1,35 @@
 #include "fans/Planar.h"
 
-Planar::Planar(const double circularDuctDiameter, const double tdx, const double pbx, const double psx)
-		: tdx(tdx), pbx(pbx), area(((3.14159265358979 / 4) * (circularDuctDiameter * circularDuctDiameter)) / 144.0),
-		  psx(psx)
+Planar::Planar(const double area, const double tdx, const double pbx, const double psx)
+		: dryBulbTemperature(tdx), barometricPressure(pbx), area(area), staticPressure(psx)
 {}
 
-Planar::Planar(const double length, const double width, const double tdx, const double pbx, const double psx,
-               const unsigned noInletBoxes)
-		: tdx(tdx), pbx(pbx), area((length * width * noInletBoxes) / 144.0), psx(psx)
-{}
+FanInletFlange::FanInletFlange(const double area, const double tdx, const double pbx)
+		: Planar(area, tdx, pbx, 0) {}
 
-FanInletFlange::FanInletFlange(const double circularDuctDiameter, const double tdx, const double pbx)
-		: Planar(circularDuctDiameter, tdx, pbx, 0) {}
+FanOrEvaseOutletFlange::FanOrEvaseOutletFlange(const double area, const double tdx, const double pbx)
+		: Planar(area, tdx, pbx, 0) {}
 
-FanInletFlange::FanInletFlange(const double length, const double width, const double tdx, const double pbx,
-                               const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, 0, noInletBoxes)
-{}
-
-FanOrEvaseOutletFlange::FanOrEvaseOutletFlange(const double circularDuctDiameter, const double tdx, const double pbx)
-		: Planar(circularDuctDiameter, tdx, pbx, 0) {}
-
-FanOrEvaseOutletFlange::FanOrEvaseOutletFlange(const double length, const double width,
-                                               const double tdx, const double pbx, const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, 0, noInletBoxes)
-{}
-
-FlowTraverse::FlowTraverse(const double circularDuctDiameter, const double tdx, const double pbx,
+FlowTraverse::FlowTraverse(const double area, const double tdx, const double pbx,
                            const double psx, const double pitotTubeCoefficient,
                            std::vector< std::vector< double > > traverseHoleData)
-		: Planar(circularDuctDiameter, tdx, pbx, psx),
+		: Planar(area, tdx, pbx, psx),
 		  VelocityPressureTraverseData(pitotTubeCoefficient, std::move(traverseHoleData))
 {}
 
-FlowTraverse::FlowTraverse(const double length, const double width, const double tdx, const double pbx,
-                           const double psx, const double pitotTubeCoefficient,
-                           std::vector< std::vector< double > > traverseHoleData, const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, psx, noInletBoxes),
-		  VelocityPressureTraverseData(pitotTubeCoefficient, std::move(traverseHoleData))
-{}
-
-AddlTravPlane::AddlTravPlane(const double circularDuctDiameter, const double tdx, const double pbx,
+AddlTravPlane::AddlTravPlane(const double area, const double tdx, const double pbx,
                              const double psx, const double pitotTubeCoefficient,
                              std::vector< std::vector< double > > traverseHoleData)
-		: Planar(circularDuctDiameter, tdx, pbx, psx),
+		: Planar(area, tdx, pbx, psx),
 		  VelocityPressureTraverseData(pitotTubeCoefficient, std::move(traverseHoleData))
 {}
 
-AddlTravPlane::AddlTravPlane(const double length, const double width, const double tdx, const double pbx,
-                             const double psx, const double pitotTubeCoefficient,
-                             std::vector< std::vector< double > > traverseHoleData, const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, psx, noInletBoxes),
-		  VelocityPressureTraverseData(pitotTubeCoefficient, std::move(traverseHoleData))
-{}
+InletMstPlane::InletMstPlane(const double area, const double tdx, const double pbx, const double psx)
+		: Planar(area, tdx, pbx, psx) {}
 
-InletMstPlane::InletMstPlane(const double circularDuctDiameter, const double tdx, const double pbx, const double psx)
-		: Planar(circularDuctDiameter, tdx, pbx, psx) {}
-
-InletMstPlane::InletMstPlane(const double length, const double width, const double tdx, const double pbx,
-                             const double psx, const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, psx, noInletBoxes)
-{}
-
-OutletMstPlane::OutletMstPlane(const double circularDuctDiameter, const double tdx, const double pbx,
+OutletMstPlane::OutletMstPlane(const double area, const double tdx, const double pbx,
                                const double psx)
-		: Planar(circularDuctDiameter, tdx, pbx, psx) {}
-
-OutletMstPlane::OutletMstPlane(const double length, const double width, const double tdx, const double pbx,
-                               const double psx, const unsigned noInletBoxes)
-		: Planar(length, width, tdx, pbx, psx, noInletBoxes)
-{}
+		: Planar(area, tdx, pbx, psx) {}
 
 VelocityPressureTraverseData::VelocityPressureTraverseData(const double pitotTubeCoefficient,
                                                            std::vector< std::vector< double > > traverseHoleData)

--- a/tests/Fan.unit.cpp
+++ b/tests/Fan.unit.cpp
@@ -17,10 +17,11 @@ TEST_CASE( "Fan", "[Fan]") {
 			}
 	};
 
-	FanInletFlange fanInletFlange(143.63, 32.63, 123, 26.57, 2);
-	FanOrEvaseOutletFlange fanOrEvaseOutletFlange(70, 78, 132.7, 26.57);
+	const double area = (143.63 * 32.63 * 2) / 144.0;
+	FanInletFlange fanInletFlange(area, 123, 26.57);
+	FanOrEvaseOutletFlange fanOrEvaseOutletFlange(70 * 78 / 144.0, 132.7, 26.57);
 
-	FlowTraverse flowTraverse(143.63, 32.63, 123.0, 26.57, -18.1, std::sqrt(0.762), traverseHoleData);
+	FlowTraverse flowTraverse(143.63 * 32.63 / 144.0, 123.0, 26.57, -18.1, std::sqrt(0.762), traverseHoleData);
 
 	traverseHoleData = {
 			{
@@ -35,11 +36,11 @@ TEST_CASE( "Fan", "[Fan]") {
 	};
 
 	std::vector<AddlTravPlane> addlTravPlanes({
-			                                          {143.63, 32.63, 123.0, 26.57, -17.0, std::sqrt(0.762), traverseHoleData}
+			                                          {143.63 * 32.63 / 144.0, 123.0, 26.57, -17.0, std::sqrt(0.762), traverseHoleData}
 	                                          });
 
-	InletMstPlane inletMstPlane(143.63, 32.63, 123.0, 26.57, -17.55, 2);
-	OutletMstPlane outletMstPlane(55.42, 60.49, 132.7, 26.57, 1.8);
+	InletMstPlane inletMstPlane(area, 123.0, 26.57, -17.55);
+	OutletMstPlane outletMstPlane(55.42 * 60.49 / 144.0, 132.7, 26.57, 1.8);
 
 	auto planeData = PlaneData(fanInletFlange, fanOrEvaseOutletFlange, flowTraverse, addlTravPlanes, inletMstPlane,
 	                           outletMstPlane, 0, 0.627, true);
@@ -53,19 +54,9 @@ TEST_CASE( "Fan", "[Fan]") {
 	auto fan = Fan(fanRatedInfo, planeData, baseGasDensity, fanShaftPower);
 	auto results = fan.calculate();
 
-	auto const fanEfficiencyTp = results["fanEfficiencyTp"];
-	auto const fanEfficiencySp = results["fanEfficiencySp"];
-	auto const fanEfficiencySpr = results["fanEfficiencySpr"];
-	auto const Qc = results["Qc"];
-	auto const Ptc = results["Ptc"];
-	auto const Psc = results["Psc"];
-	auto const SPRc = results["SPRc"];
-	auto const Hc = results["Hc"];
-	auto const Kpc = results["Kpc"];
-
-	CHECK(fanEfficiencyTp == Approx(53.607386));
-	CHECK(fanEfficiencySp == Approx(49.206914));
-	CHECK(fanEfficiencySpr == Approx(50.768875));
+	CHECK(results.fanEfficiencyTotalPressure == Approx(53.607386));
+	CHECK(results.fanEfficiencyStaticPressure == Approx(49.206914));
+	CHECK(results.fanEfficiencyStaticPressureRise == Approx(50.768875));
 	// TODO add checks for other stuff besides efficiency
 }
 

--- a/tests/js/fanTest.js
+++ b/tests/js/fanTest.js
@@ -9,6 +9,8 @@ function rnd(value) {
 test('fan test', function (t) {
     t.plan(4);
     t.type(bindings.fan203, 'function');
+
+    var area = 143.63 * 32.63 / 144.0;
     var inp = {
         FanRatedInfo: {
             fanSpeed: 1191,
@@ -22,22 +24,18 @@ test('fan test', function (t) {
             totalPressureLossBtwnPlanes1and4: 0,
             totalPressureLossBtwnPlanes2and5: 0.627,
             FanInletFlange: {
-                width: 143.63,
+                area: area * 2,
                 length: 32.63,
                 tdx: 123,
-                pbx: 26.57,
-                noInletBoxes: 2
+                pbx: 26.57
             },
             FanEvaseOrOutletFlange: {
-                width: 70,
-                length: 78,
+                area: 70 * 78 / 144.0,
                 tdx: 132.7,
                 pbx: 26.57
-                // noInletBoxes isn't necessary, will default to 1
             },
             FlowTraverse: {
-                width: 143.63,
-                length: 32.63,
+                area: area,
                 tdx: 123,
                 pbx: 26.57,
                 psx: -18.1,
@@ -50,8 +48,7 @@ test('fan test', function (t) {
             },
             AddlTraversePlanes: [
                 {
-                    width: 143.63,
-                    length: 32.63,
+                    area: area,
                     tdx: 123,
                     pbx: 26.57,
                     psx: -17.0,
@@ -64,20 +61,16 @@ test('fan test', function (t) {
                 }
             ],
             InletMstPlane: {
-                width: 143.63,
-                length: 32.63,
+                area: area * 2,
                 tdx: 123,
                 pbx: 26.57,
-                psx: -17.55,
-                noInletBoxes: 2
+                psx: -17.55
             },
             OutletMstPlane: {
-                width: 55.42,
-                length: 60.49,
+                area: (55.42 * 60.49) / 144.0,
                 tdx: 132.7,
                 pbx: 26.57,
                 psx: 1.8
-                // noInletBoxes not provided here.. defaults to 1
             }
         },
         BaseGasDensity: {
@@ -101,9 +94,9 @@ test('fan test', function (t) {
 
     var res = bindings.fan203(inp);
 
-    t.equal(rnd(res.fanEfficiencyTp), rnd(53.60738684355601));
-    t.equal(rnd(res.fanEfficiencySp), rnd(49.20691409764023));
-    t.equal(rnd(res.fanEfficiencySpr), rnd(50.768875240824116));
+    t.equal(rnd(res.fanEfficiencyTotalPressure), rnd(53.60738684355601));
+    t.equal(rnd(res.fanEfficiencyStaticPressure), rnd(49.20691409764023));
+    t.equal(rnd(res.fanEfficiencyStaticPressureRise), rnd(50.768875240824116));
 });
 
 test('fan curve test', function (t) {


### PR DESCRIPTION
connect #196 

Updates fan bindings, cuts the constructor numbers in half by requiring area to be passed in instead of simply calculated in the constructor initialization lists. Makes return value variable names in the bindings more explicit