### PR TITLE
Add usable air capacity NAN binding

### DIFF
--- a/bindings/standalone.cpp
+++ b/bindings/standalone.cpp
@@ -9,6 +9,9 @@ NAN_MODULE_INIT(InitStandalone) {
 
 	Nan::Set(target, New<String>("pneumaticAirRequirement").ToLocalChecked(),
 	         GetFunction(New<FunctionTemplate>(pneumaticAirRequirement)).ToLocalChecked());
+	
+	Nan::Set(target, New<String>("usableAirCapacity").ToLocalChecked(),
+			 GetFunction(New<FunctionTemplate>(usableAirCapacity)).ToLocalChecked());
 
 	Nan::Set(target, New<String>("receiverTank").ToLocalChecked(),
 	         GetFunction(New<FunctionTemplate>(receiverTank)).ToLocalChecked());

--- a/bindings/standalone.h
+++ b/bindings/standalone.h
@@ -54,12 +54,14 @@ NAN_METHOD(CHPcalculator) {
 	info.GetReturnValue().Set(r);
 }
 
+NAN_METHOD(usableAirCapacity) {
+	inp = info[0]->ToObject();
+	info.GetReturnValue().Set(ReceiverTank::calculateUsableCapacity(Get("tankSize"), Get("airPressureIn"), Get("airPressureOut")));
+}
+
 NAN_METHOD(pneumaticAirRequirement) {
 	inp = info[0]->ToObject();
 	r = Nan::New<Object>();
-
-//	unsigned val = static_cast<unsigned>(Get("pistonType"));
-//	PneumaticAirRequirement::PistonType pistonType = static_cast<PneumaticAirRequirement::PistonType>(val);
 
 	int val = Get("pistonType");
 	auto const pistonType = (!val) ? PneumaticAirRequirement::PistonType::SingleActing : PneumaticAirRequirement::PistonType::DoubleActing;

--- a/include/calculator/util/CompressedAir.h
+++ b/include/calculator/util/CompressedAir.h
@@ -140,7 +140,9 @@ public:
 	 * @param airPressureOut double, a.	Pressure of air leaving the Tank - psi
 	 * @return double, Useable air storage capacity - scf
 	 */
-	static double calculateUsableCapacity(double tankSize, double airPressureIn, double airPressureOut);
+	static double calculateUsableCapacity(const double tankSize, const double airPressureIn, const double airPressureOut) {
+		return (tankSize / 7.48) * (airPressureIn - airPressureOut) / 14.7;
+	}
 
 	/**
 	 * Calculates and returns receiver tank useable air capacity

--- a/src/calculator/util/CompressedAir.cpp
+++ b/src/calculator/util/CompressedAir.cpp
@@ -34,12 +34,6 @@ PneumaticAirRequirement::Output PneumaticAirRequirement::calculate() {
 	return {volumeAirIntakeDouble, compressionRatio, volumeAirIntakeDouble * compressionRatio};
 }
 
-double ReceiverTank::calculateUsableCapacity(const double tankSize, const double airPressureIn,
-                                             const double airPressureOut)
-{
-	return (tankSize / 7.48) * (airPressureIn - airPressureOut) / 14.7;
-}
-
 ReceiverTank::ReceiverTank(const Method method, const double airDemand, const double allowablePressureDrop,
                            const double atmosphericPressure)
 		: method(method), airDemand(airDemand), allowablePressureDrop(allowablePressureDrop),

--- a/tests/js/standalone.js
+++ b/tests/js/standalone.js
@@ -67,6 +67,15 @@ test('PneumaticAirRequirement', function (t) {
     compare(bindings.pneumaticAirRequirement(input), [0.712939, 7.802721, 5.562868]);
 });
 
+test('usableAirCapacity', function (t) {
+    t.plan(5);
+    t.type(bindings.usableAirCapacity, 'function');
+    t.equal(rnd(bindings.usableAirCapacity({tankSize: 660, airPressureIn: 110, airPressureOut: 100})), rnd(60.024009603));
+    t.equal(rnd(bindings.usableAirCapacity({tankSize: 760, airPressureIn: 110, airPressureOut: 100})), rnd(69.1185565135));
+    t.equal(rnd(bindings.usableAirCapacity({tankSize: 760, airPressureIn: 150, airPressureOut: 100})), rnd(345.5927825676));
+    t.equal(rnd(bindings.usableAirCapacity({tankSize: 760, airPressureIn: 150, airPressureOut: 130})), rnd(138.237113027));
+});
+
 test('Receiver Tank Size', function (t) {
     t.plan(9);
     t.type(bindings.receiverTank, 'function');


### PR DESCRIPTION
connect #210 

- Adds usable air capacity binding `usableAirCapacity`
- Moves the definition of the `calculateUsableCapacity` static C++ function to the header file