### PR TITLE
Steam output refactor

### DIFF
--- a/bindings/ssmt.h
+++ b/bindings/ssmt.h
@@ -65,10 +65,6 @@ NAN_METHOD(saturatedPressure) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    /**
-     * Constructor for Saturated Pressure class
-     * @param saturatedTemperature double, saturated temperature in K
-     */
     SaturatedPressure sp(Get("saturatedTemperature"));
     SetR("saturatedPressure", sp.calculate());
     info.GetReturnValue().Set(r);
@@ -78,10 +74,6 @@ NAN_METHOD(saturatedTemperature) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    /**
-     * Constructor for the Saturated Temperature class
-     * @param saturatedPressure double, saturatedPressure in MPa
-     */
     SaturatedTemperature st(Get("saturatedPressure"));
     SetR("saturatedTemperature", st.calculate());
     info.GetReturnValue().Set(r);
@@ -92,26 +84,19 @@ NAN_METHOD(saturatedPropertiesGivenTemperature) {
     r = Nan::New<Object>();
 
     double const pressure = SaturatedPressure(Get("saturatedTemperature")).calculate();
+    auto const results = SaturatedProperties(pressure, Get("saturatedTemperature")).calculate();
 
-    /**
-     * Constructor for Saturated Properties class
-     * @param pressure double, saturated pressure in MPa
-     * @param saturatedTemperature double, saturated temperature in K
-     */
-    SaturatedProperties sp(pressure, Get("saturatedTemperature"));
-    auto const results = sp.calculate();
-
-    SetR("saturatedPressure", results.at("pressure"));
-    SetR("saturatedTemperature", results.at("temperature"));
-    SetR("liquidEnthalpy", results.at("liquidSpecificEnthalpy"));
-    SetR("gasEnthalpy", results.at("gasSpecificEnthalpy"));
-    SetR("evaporationEnthalpy", results.at("evaporationSpecificEnthalpy"));
-    SetR("liquidEntropy", results.at("liquidSpecificEntropy"));
-    SetR("gasEntropy", results.at("gasSpecificEntropy"));
-    SetR("evaporationEntropy", results.at("evaporationSpecificEntropy"));
-    SetR("liquidVolume", results.at("liquidSpecificVolume"));
-    SetR("gasVolume", results.at("gasSpecificVolume"));
-    SetR("evaporationVolume", results.at("evaporationSpecificVolume"));
+    SetR("saturatedPressure", results.pressure);
+    SetR("saturatedTemperature", results.temperature);
+    SetR("liquidEnthalpy", results.liquidSpecificEnthalpy);
+    SetR("gasEnthalpy", results.gasSpecificEnthalpy);
+    SetR("evaporationEnthalpy", results.evaporationSpecificEnthalpy);
+    SetR("liquidEntropy", results.liquidSpecificEntropy);
+    SetR("gasEntropy", results.gasSpecificEntropy);
+    SetR("evaporationEntropy", results.evaporationSpecificEntropy);
+    SetR("liquidVolume", results.liquidSpecificVolume);
+    SetR("gasVolume", results.gasSpecificVolume);
+    SetR("evaporationVolume", results.evaporationSpecificVolume);
     info.GetReturnValue().Set(r);
 }
 
@@ -121,24 +106,18 @@ NAN_METHOD(saturatedPropertiesGivenPressure) {
     r = Nan::New<Object>();
 
     double const temperature = SaturatedTemperature(Get("saturatedPressure")).calculate();
-
-    /**
-     * Constructor for Saturated Properties class
-     * @param saturatedPressure double, saturated pressure in MPa
-     * @param temperature double, saturated temperature in K
-     */
     auto const results = SaturatedProperties(Get("saturatedPressure"), temperature).calculate();
-    SetR("saturatedPressure", results.at("pressure"));
-    SetR("saturatedTemperature", results.at("temperature"));
-    SetR("liquidEnthalpy", results.at("liquidSpecificEnthalpy"));
-    SetR("gasEnthalpy", results.at("gasSpecificEnthalpy"));
-    SetR("evaporationEnthalpy", results.at("evaporationSpecificEnthalpy"));
-    SetR("liquidEntropy", results.at("liquidSpecificEntropy"));
-    SetR("gasEntropy", results.at("gasSpecificEntropy"));
-    SetR("evaporationEntropy", results.at("evaporationSpecificEntropy"));
-    SetR("liquidVolume", results.at("liquidSpecificVolume"));
-    SetR("gasVolume", results.at("gasSpecificVolume"));
-    SetR("evaporationVolume", results.at("evaporationSpecificVolume"));
+    SetR("saturatedPressure", results.pressure);
+    SetR("saturatedTemperature", results.temperature);
+    SetR("liquidEnthalpy", results.liquidSpecificEnthalpy);
+    SetR("gasEnthalpy", results.gasSpecificEnthalpy);
+    SetR("evaporationEnthalpy", results.evaporationSpecificEnthalpy);
+    SetR("liquidEntropy", results.liquidSpecificEntropy);
+    SetR("gasEntropy", results.gasSpecificEntropy);
+    SetR("evaporationEntropy", results.evaporationSpecificEntropy);
+    SetR("liquidVolume", results.liquidSpecificVolume);
+    SetR("gasVolume", results.gasSpecificVolume);
+    SetR("evaporationVolume", results.evaporationSpecificVolume);
     info.GetReturnValue().Set(r);
 }
 
@@ -148,20 +127,13 @@ NAN_METHOD(steamProperties) {
     r = Nan::New<Object>();
 
     SteamProperties::ThermodynamicQuantity quantity = thermodynamicQuantity();
-
-    /**
-     * Constructor for Steam Properties class
-     * @param pressure double, saturated pressure in MPa
-     * @param quantity SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, specific enthalpy in kJ/kg, specific entropy in kJ/kg/K, or saturated quality - unitless)
-     * @param quantityValue double, value of either temperature in K, specific enthalpy in kJ/kg, specific entropy in kJ/kg/K, or saturated quality - unitless
-     */
     auto const results = SteamProperties(Get("pressure"), quantity, Get("quantityValue")).calculate();
-    SetR("pressure", results.at("pressure"));
-    SetR("temperature", results.at("temperature"));
-    SetR("specificEnthalpy", results.at("specificEnthalpy"));
-    SetR("specificEntropy", results.at("specificEntropy"));
-    SetR("quality", results.at("quality"));
-    SetR("specificVolume", results.at("specificVolume"));
+    SetR("pressure", results.pressure);
+    SetR("temperature", results.temperature);
+    SetR("specificEnthalpy", results.specificEnthalpy);
+    SetR("specificEntropy", results.specificEntropy);
+    SetR("quality", results.quality);
+    SetR("specificVolume", results.specificVolume);
     info.GetReturnValue().Set(r);
 }
 
@@ -175,31 +147,31 @@ NAN_METHOD(boiler) {
     auto const b = Boiler(Get("deaeratorPressure"), Get("combustionEfficiency"), Get("blowdownRate"), Get("steamPressure"), quantityType, Get("quantityValue"), Get("steamMassFlow"));
 
     auto const results = b.getSteamProperties();
-    SetR("steamPressure", results.at("pressure"));
-    SetR("steamTemperature", results.at("temperature"));
-    SetR("steamSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("steamSpecificEntropy", results.at("specificEntropy"));
-    SetR("steamQuality", results.at("quality"));
-    SetR("steamMassFlow", results.at("steamMassFlow"));
-    SetR("steamEnergyFlow", results.at("steamEnergyFlow"));
+    SetR("steamPressure", results.pressure);
+    SetR("steamTemperature", results.temperature);
+    SetR("steamSpecificEnthalpy", results.specificEnthalpy);
+    SetR("steamSpecificEntropy", results.specificEntropy);
+    SetR("steamQuality", results.quality);
+    SetR("steamMassFlow", results.massFlow);
+    SetR("steamEnergyFlow", results.energyFlow);
 
     auto const results2 = b.getBlowdownProperties();
-    SetR("blowdownPressure", results2.at("pressure"));
-    SetR("blowdownTemperature", results2.at("temperature"));
-    SetR("blowdownSpecificEnthalpy", results2.at("specificEnthalpy"));
-    SetR("blowdownSpecificEntropy", results2.at("specificEntropy"));
-    SetR("blowdownQuality", results2.at("quality"));
-    SetR("blowdownMassFlow", results2.at("blowdownMassFlow"));
-    SetR("blowdownEnergyFlow", results2.at("blowdownEnergyFlow"));
+    SetR("blowdownPressure", results2.pressure);
+    SetR("blowdownTemperature", results2.temperature);
+    SetR("blowdownSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("blowdownSpecificEntropy", results2.specificEntropy);
+    SetR("blowdownQuality", results2.quality);
+    SetR("blowdownMassFlow", results2.massFlow);
+    SetR("blowdownEnergyFlow", results2.energyFlow);
 
 	auto const results3 = b.getFeedwaterProperties();
-    SetR("feedwaterPressure", results3.at("pressure"));
-    SetR("feedwaterTemperature", results3.at("temperature"));
-    SetR("feedwaterSpecificEnthalpy", results3.at("specificEnthalpy"));
-    SetR("feedwaterSpecificEntropy", results3.at("specificEntropy"));
-    SetR("feedwaterQuality", results3.at("quality"));
-    SetR("feedwaterMassFlow", results3.at("feedwaterMassFlow"));
-    SetR("feedwaterEnergyFlow", results3.at("feedwaterEnergyFlow"));
+    SetR("feedwaterPressure", results3.pressure);
+    SetR("feedwaterTemperature", results3.temperature);
+    SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
+    SetR("feedwaterSpecificEntropy", results3.specificEntropy);
+    SetR("feedwaterQuality", results3.quality);
+    SetR("feedwaterMassFlow", results3.massFlow);
+    SetR("feedwaterEnergyFlow", results3.energyFlow);
     SetR("boilerEnergy", b.getBoilerEnergy());
     SetR("fuelEnergy", b.getFuelEnergy());
 
@@ -211,37 +183,25 @@ NAN_METHOD(heatLoss) {
     r = Nan::New<Object>();
 
     SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
-    /**
- *
- * Constructor for the heat loss calculator
- *
- * @param inletPressure double, inlet pressure in MPa
- * @param quantityType SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
- * @param quantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
- * @param inletMassFlow double, inlet mass flow in kg/hr
- * @param percentHeatLoss double, heat loss as %
- *
- *
- * */
-    auto hl = HeatLoss(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("percentHeatLoss"));
+    auto const hl = HeatLoss(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("percentHeatLoss"));
     auto const results = hl.getInletProperties();
 
-    SetR("inletPressure", results.at("pressure"));
-    SetR("inletTemperature", results.at("temperature"));
-    SetR("inletSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("inletSpecificEntropy", results.at("specificEntropy"));
-    SetR("inletQuality", results.at("quality"));
-    SetR("inletMassFlow", results.at("massFlow"));
-    SetR("inletEnergyFlow", results.at("energyFlow"));
+    SetR("inletPressure", results.pressure);
+    SetR("inletTemperature", results.temperature);
+    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+    SetR("inletSpecificEntropy", results.specificEntropy);
+    SetR("inletQuality", results.quality);
+    SetR("inletMassFlow", results.massFlow);
+    SetR("inletEnergyFlow", results.energyFlow);
 
     auto const results2 = hl.getOutletProperties();
-    SetR("outletPressure", results2.at("pressure"));
-    SetR("outletTemperature", results2.at("temperature"));
-    SetR("outletSpecificEnthalpy", results2.at("specificEnthalpy"));
-    SetR("outletSpecificEntropy", results2.at("specificEntropy"));
-    SetR("outletQuality", results2.at("quality"));
-    SetR("outletMassFlow", results2.at("massFlow"));
-    SetR("outletEnergyFlow", results2.at("energyFlow"));
+    SetR("outletPressure", results2.pressure);
+    SetR("outletTemperature", results2.temperature);
+    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("outletSpecificEntropy", results2.specificEntropy);
+    SetR("outletQuality", results2.quality);
+    SetR("outletMassFlow", results2.massFlow);
+    SetR("outletEnergyFlow", results2.energyFlow);
     SetR("heatLoss", hl.getHeatLoss());
 
     info.GetReturnValue().Set(r);
@@ -253,45 +213,34 @@ NAN_METHOD(flashTank) {
 
     SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
 
-    /**
-	*
-	* Constructor for the flash tank calculator
-	*
-	* @param inletWaterPressure double, inlet water pressure in MPa
-	* @param quantityType SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-	* @param quantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-	* @param inletWaterMassFlow double, inlet water mass flow in kg/hr
-	* @param tankPressure double, pressure of the tank in MPa
-	*
-	*
-	* */
     auto const ft = FlashTank(Get("inletWaterPressure"), quantityType, Get("quantityValue"), Get("inletWaterMassFlow"), Get("tankPressure"));
 
     auto const results = ft.getInletWaterProperties();
-    SetR("inletWaterPressure", results.at("pressure"));
-    SetR("inletWaterTemperature", results.at("temperature"));
-    SetR("inletWaterSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("inletWaterSpecificEntropy", results.at("specificEntropy"));
-    SetR("inletWaterQuality", results.at("quality"));
-    SetR("inletWaterMassFlow", results.at("massFlow"));
-    SetR("inletWaterEnergyFlow", results.at("energyFlow"));
+    SetR("inletWaterPressure", results.pressure);
+    SetR("inletWaterTemperature", results.temperature);
+    SetR("inletWaterSpecificEnthalpy", results.specificEnthalpy);
+    SetR("inletWaterSpecificEntropy", results.specificEntropy);
+    SetR("inletWaterQuality", results.quality);
+    SetR("inletWaterMassFlow", results.massFlow);
+    SetR("inletWaterEnergyFlow", results.energyFlow);
 
-    auto const results2 = ft.getOutletSaturatedProperties();
-    SetR("outletGasPressure", results2.at("pressure"));
-    SetR("outletGasTemperature", results2.at("temperature"));
-    SetR("outletGasSpecificEnthalpy", results2.at("gasSpecificEnthalpy"));
-    SetR("outletGasSpecificEntropy", results2.at("gasSpecificEntropy"));
+    auto const results2 = ft.getOutletGasSaturatedProperties();
+    SetR("outletGasPressure", results2.pressure);
+    SetR("outletGasTemperature", results2.temperature);
+    SetR("outletGasSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("outletGasSpecificEntropy", results2.specificEntropy);
     SetR("outletGasQuality", 1);
-    SetR("outletGasMassFlow", results2.at("gasMassFlow"));
-    SetR("outletGasEnergyFlow", results2.at("gasEnergyFlow"));
+    SetR("outletGasMassFlow", results2.massFlow);
+    SetR("outletGasEnergyFlow", results2.energyFlow);
 
-    SetR("outletLiquidPressure", results2.at("pressure"));
-    SetR("outletLiquidTemperature", results2.at("temperature"));
-    SetR("outletLiquidSpecificEnthalpy", results2.at("liquidSpecificEnthalpy"));
-    SetR("outletLiquidSpecificEntropy", results2.at("liquidSpecificEntropy"));
+    auto const results3 = ft.getOutletLiquidSaturatedProperties();
+    SetR("outletLiquidPressure", results3.pressure);
+    SetR("outletLiquidTemperature", results3.temperature);
+    SetR("outletLiquidSpecificEnthalpy", results3.specificEnthalpy);
+    SetR("outletLiquidSpecificEntropy", results3.specificEntropy);
     SetR("outletLiquidQuality", 0);
-    SetR("outletLiquidMassFlow", results2.at("liquidMassFlow"));
-    SetR("outletLiquidEnergyFlow", results2.at("liquidEnergyFlow"));
+    SetR("outletLiquidMassFlow", results3.massFlow);
+    SetR("outletLiquidEnergyFlow", results3.energyFlow);
 
     info.GetReturnValue().Set(r);
 }
@@ -301,36 +250,23 @@ NAN_METHOD(prvWithoutDesuperheating) {
     r = Nan::New<Object>();
 
     SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+    auto const pwod = PrvWithoutDesuperheating(Get("inletPressure"),quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("outletPressure"));
 
-   /**
-    *
-    * Constructor for the PRV without desuperheating calculator
-    *
-    * @param inletPressure double, inlet pressure in MPa
-    * @param quantityType SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-    * @param quantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-    * @param inletMassFlow double, inlet mass flow in kg/hr
-    * @param outletPressure double, houtlet pressure in MPa
-    *
-    *
-    * */
-    auto pwod = PrvWithoutDesuperheating(Get("inletPressure"),quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("outletPressure"));
-
-    auto results = pwod.getInletProperties();
-    SetR("inletPressure", results.at("pressure"));
-    SetR("inletTemperature", results.at("temperature"));
-    SetR("inletSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("inletSpecificEntropy", results.at("specificEntropy"));
-    SetR("inletQuality", results.at("quality"));
+    auto const results = pwod.getInletProperties();
+    SetR("inletPressure", results.pressure);
+    SetR("inletTemperature", results.temperature);
+    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+    SetR("inletSpecificEntropy", results.specificEntropy);
+    SetR("inletQuality", results.quality);
     SetR("inletMassFlow", pwod.getInletMassFlow());
     SetR("inletEnergyFlow", pwod.getInletEnergyFlow());
 
-    auto results2= pwod.getOutletProperties();
-    SetR("outletPressure", results2.at("pressure"));
-    SetR("outletTemperature", results2.at("temperature"));
-    SetR("outletSpecificEnthalpy", results2.at("specificEnthalpy"));
-    SetR("outletSpecificEntropy", results2.at("specificEntropy"));
-    SetR("outletQuality", results2.at("quality"));
+    auto const results2 = pwod.getOutletProperties();
+    SetR("outletPressure", results2.pressure);
+    SetR("outletTemperature", results2.temperature);
+    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("outletSpecificEntropy", results2.specificEntropy);
+    SetR("outletQuality", results2.quality);
     SetR("outletMassFlow", pwod.getOutletMassFlow());
     SetR("outletEnergyFlow", pwod.getOutletEnergyFlow());
 
@@ -345,48 +281,34 @@ NAN_METHOD(prvWithDesuperheating) {
     SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
     SteamProperties::ThermodynamicQuantity feedwaterQuantityType = feedwaterThermodynamicQuantity();
 
-    /**
-     *
-     * Constructor for the PRV with desuperheating calculator
-     *
-     * @param inletPressure double, inlet pressure in MPa
-     * @param quantityType SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-     * @param quantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-     * @param inletMassFlow double, inlet mass flow in kg/hr
-     * @param outletPressure double, outlet pressure in MPa
-     * @param feedwaterPressure double, pressure of feedwater in MPa
-     * @param feedwaterQuantityType SteamProperties::ThermodynamicQuantity, type of quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-     * @param feedwaterQuantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
-     * @param desuperheatingTemp double, desuperheating temperature in K
-     *
-     *
-     * */
-    auto pwd = PrvWithDesuperheating(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("outletPressure"), Get("feedwaterPressure"), feedwaterQuantityType, Get("feedwaterQuantityValue"), Get("desuperheatingTemp"));
+    auto const pwd = PrvWithDesuperheating(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"),
+                                           Get("outletPressure"), Get("feedwaterPressure"), feedwaterQuantityType,
+                                           Get("feedwaterQuantityValue"), Get("desuperheatingTemp"));
 
-    auto results = pwd.getInletProperties();
-    SetR("inletPressure", results.at("pressure"));
-    SetR("inletTemperature", results.at("temperature"));
-    SetR("inletSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("inletSpecificEntropy", results.at("specificEntropy"));
-    SetR("inletQuality", results.at("quality"));
+    auto const results = pwd.getInletProperties();
+    SetR("inletPressure", results.pressure);
+    SetR("inletTemperature", results.temperature);
+    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+    SetR("inletSpecificEntropy", results.specificEntropy);
+    SetR("inletQuality", results.quality);
     SetR("inletMassFlow", pwd.getInletMassFlow());
     SetR("inletEnergyFlow", pwd.getInletEnergyFlow());
 
-    auto results2 = pwd.getOutletProperties();
-    SetR("outletPressure", results2.at("pressure"));
-    SetR("outletTemperature", results2.at("temperature"));
-    SetR("outletSpecificEnthalpy", results2.at("specificEnthalpy"));
-    SetR("outletSpecificEntropy", results2.at("specificEntropy"));
-    SetR("outletQuality", results2.at("quality"));
+    auto const results2 = pwd.getOutletProperties();
+    SetR("outletPressure", results2.pressure);
+    SetR("outletTemperature", results2.temperature);
+    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("outletSpecificEntropy", results2.specificEntropy);
+    SetR("outletQuality", results2.quality);
     SetR("outletMassFlow", pwd.getOutletMassFlow());
     SetR("outletEnergyFlow", pwd.getOutletEnergyFlow());
 
-    auto results3 = pwd.getFeedwaterProperties();
-    SetR("feedwaterPressure", results3.at("pressure"));
-    SetR("feedwaterTemperature", results3.at("temperature"));
-    SetR("feedwaterSpecificEnthalpy", results3.at("specificEnthalpy"));
-    SetR("feedwaterSpecificEntropy", results3.at("specificEntropy"));
-    SetR("feedwaterQuality", results3.at("quality"));
+    auto const results3 = pwd.getFeedwaterProperties();
+    SetR("feedwaterPressure", results3.pressure);
+    SetR("feedwaterTemperature", results3.temperature);
+    SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
+    SetR("feedwaterSpecificEntropy", results3.specificEntropy);
+    SetR("feedwaterQuality", results3.quality);
     SetR("feedwaterMassFlow", pwd.getFeedwaterMassFlow());
     SetR("feedwaterEnergyFlow", pwd.getFeedwaterEnergyFlow());
 
@@ -405,40 +327,40 @@ NAN_METHOD(deaerator) {
                 Get("steamQuantityValue"));
 
     auto const results = d.getFeedwaterProperties();
-    SetR("feedwaterPressure", results.at("pressure"));
-    SetR("feedwaterTemperature", results.at("temperature"));
-    SetR("feedwaterSpecificEnthalpy", results.at("specificEnthalpy"));
-    SetR("feedwaterSpecificEntropy", results.at("specificEntropy"));
-    SetR("feedwaterQuality", results.at("quality"));
-    SetR("feedwaterMassFlow", results.at("massFlow"));
-    SetR("feedwaterEnergyFlow", results.at("energyFlow"));
+    SetR("feedwaterPressure", results.pressure);
+    SetR("feedwaterTemperature", results.temperature);
+    SetR("feedwaterSpecificEnthalpy", results.specificEnthalpy);
+    SetR("feedwaterSpecificEntropy", results.specificEntropy);
+    SetR("feedwaterQuality", results.quality);
+    SetR("feedwaterMassFlow", results.massFlow);
+    SetR("feedwaterEnergyFlow", results.energyFlow);
 
     auto const results2 = d.getVentedSteamProperties();
-    SetR("ventedSteamPressure", results2.at("pressure"));
-    SetR("ventedSteamTemperature", results2.at("temperature"));
-    SetR("ventedSteamSpecificEnthalpy", results2.at("specificEnthalpy"));
-    SetR("ventedSteamSpecificEntropy", results2.at("specificEntropy"));
-    SetR("ventedSteamQuality", results2.at("quality"));
-    SetR("ventedSteamMassFlow", results2.at("massFlow"));
-    SetR("ventedSteamEnergyFlow", results2.at("energyFlow"));
+    SetR("ventedSteamPressure", results2.pressure);
+    SetR("ventedSteamTemperature", results2.temperature);
+    SetR("ventedSteamSpecificEnthalpy", results2.specificEnthalpy);
+    SetR("ventedSteamSpecificEntropy", results2.specificEntropy);
+    SetR("ventedSteamQuality", results2.quality);
+    SetR("ventedSteamMassFlow", results2.massFlow);
+    SetR("ventedSteamEnergyFlow", results2.energyFlow);
 
     auto const results3 = d.getInletWaterProperties();
-    SetR("inletWaterPressure", results3.at("pressure"));
-    SetR("inletWaterTemperature", results3.at("temperature"));
-    SetR("inletWaterSpecificEnthalpy", results3.at("specificEnthalpy"));
-    SetR("inletWaterSpecificEntropy", results3.at("specificEntropy"));
-    SetR("inletWaterQuality", results3.at("quality"));
-    SetR("inletWaterMassFlow", results3.at("massFlow"));
-    SetR("inletWaterEnergyFlow", results3.at("energyFlow"));
+    SetR("inletWaterPressure", results3.pressure);
+    SetR("inletWaterTemperature", results3.temperature);
+    SetR("inletWaterSpecificEnthalpy", results3.specificEnthalpy);
+    SetR("inletWaterSpecificEntropy", results3.specificEntropy);
+    SetR("inletWaterQuality", results3.quality);
+    SetR("inletWaterMassFlow", results3.massFlow);
+    SetR("inletWaterEnergyFlow", results3.energyFlow);
 
     auto const results4 = d.getInletSteamProperties();
-    SetR("inletSteamPressure", results4.at("pressure"));
-    SetR("inletSteamTemperature", results4.at("temperature"));
-    SetR("inletSteamSpecificEnthalpy", results4.at("specificEnthalpy"));
-    SetR("inletSteamSpecificEntropy", results4.at("specificEntropy"));
-    SetR("inletSteamQuality", results4.at("quality"));
-    SetR("inletSteamMassFlow", results4.at("massFlow"));
-    SetR("inletSteamEnergyFlow", results4.at("energyFlow"));
+    SetR("inletSteamPressure", results4.pressure);
+    SetR("inletSteamTemperature", results4.temperature);
+    SetR("inletSteamSpecificEnthalpy", results4.specificEnthalpy);
+    SetR("inletSteamSpecificEntropy", results4.specificEntropy);
+    SetR("inletSteamQuality", results4.quality);
+    SetR("inletSteamMassFlow", results4.massFlow);
+    SetR("inletSteamEnergyFlow", results4.energyFlow);
 
     info.GetReturnValue().Set(r);
 }
@@ -475,11 +397,11 @@ NAN_METHOD(header) {
         Local<String> inletNum = Nan::New<String>("inlet" + std::to_string(i + 1)).ToLocalChecked();
         auto const inletProps = inlets[i].getInletProperties();
 
-        Nan::Set(obj, pressureStr, Nan::New<Number>(inletProps.at("pressure")));
-        Nan::Set(obj, temperatureStr, Nan::New<Number>(inletProps.at("temperature")));
-        Nan::Set(obj, qualityStr, Nan::New<Number>(inletProps.at("quality")));
-        Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(inletProps.at("specificEnthalpy")));
-        Nan::Set(obj, specificEntropyStr, Nan::New<Number>(inletProps.at("specificEntropy")));
+        Nan::Set(obj, pressureStr, Nan::New<Number>(inletProps.pressure));
+        Nan::Set(obj, temperatureStr, Nan::New<Number>(inletProps.temperature));
+        Nan::Set(obj, qualityStr, Nan::New<Number>(inletProps.quality));
+        Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(inletProps.specificEnthalpy));
+        Nan::Set(obj, specificEntropyStr, Nan::New<Number>(inletProps.specificEntropy));
         Nan::Set(obj, energyFlowStr, Nan::New<Number>(inlets[i].getInletEnergyFlow()));
         Nan::Set(obj, massFlowStr, Nan::New<Number>(inlets[i].getMassFlow()));
 
@@ -494,10 +416,10 @@ NAN_METHOD(header) {
     Local<Object> obj = Nan::New<Object>();
 
     Nan::Set(obj, pressureStr, Nan::New<Number>(header.getHeaderPressure()));
-    Nan::Set(obj, temperatureStr, Nan::New<Number>(headerProps.at("temperature")));
-    Nan::Set(obj, qualityStr, Nan::New<Number>(headerProps.at("quality")));
-    Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(headerProps.at("specificEnthalpy")));
-    Nan::Set(obj, specificEntropyStr, Nan::New<Number>(headerProps.at("specificEntropy")));
+    Nan::Set(obj, temperatureStr, Nan::New<Number>(headerProps.temperature));
+    Nan::Set(obj, qualityStr, Nan::New<Number>(headerProps.quality));
+    Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(headerProps.specificEnthalpy));
+    Nan::Set(obj, specificEntropyStr, Nan::New<Number>(headerProps.specificEntropy));
     Nan::Set(obj, energyFlowStr, Nan::New<Number>(header.getInletEnergyFlow()));
     Nan::Set(obj, massFlowStr, Nan::New<Number>(header.getInletMassFlow()));
 
@@ -537,18 +459,20 @@ NAN_METHOD(turbine) {
         ThrowError(std::string("std::runtime_error thrown in turbine - ssmt.h: " + what).c_str());
     }
 
-    SetR("inletPressure", t->getInletProperties().at("pressure"));
-    SetR("inletTemperature", t->getInletProperties().at("temperature"));
-    SetR("inletSpecificEnthalpy", t->getInletProperties().at("specificEnthalpy"));
-    SetR("inletSpecificEntropy", t->getInletProperties().at("specificEntropy"));
-    SetR("inletQuality", t->getInletProperties().at("quality"));
+	auto results = t->getInletProperties();
+    SetR("inletPressure", results.pressure);
+    SetR("inletTemperature", results.temperature);
+    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+    SetR("inletSpecificEntropy", results.specificEntropy);
+    SetR("inletQuality", results.quality);
     SetR("inletEnergyFlow", t->getInletEnergyFlow());
 
-    SetR("outletPressure", t->getOutletProperties().at("pressure"));
-    SetR("outletTemperature", t->getOutletProperties().at("temperature"));
-    SetR("outletSpecificEnthalpy", t->getOutletProperties().at("specificEnthalpy"));
-    SetR("outletSpecificEntropy", t->getOutletProperties().at("specificEntropy"));
-    SetR("outletQuality", t->getOutletProperties().at("quality"));
+	results = t->getOutletProperties();
+    SetR("outletPressure", results.pressure);
+    SetR("outletTemperature", results.temperature);
+    SetR("outletSpecificEnthalpy", results.specificEnthalpy);
+    SetR("outletSpecificEntropy", results.specificEntropy);
+    SetR("outletQuality", results.quality);
     SetR("outletEnergyFlow", t->getOutletEnergyFlow());
 
     SetR("massFlow", t->getMassFlow());

--- a/bindings/ssmt.h
+++ b/bindings/ssmt.h
@@ -126,14 +126,19 @@ NAN_METHOD(steamProperties) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantity = thermodynamicQuantity();
-    auto const results = SteamProperties(Get("pressure"), quantity, Get("quantityValue")).calculate();
-    SetR("pressure", results.pressure);
-    SetR("temperature", results.temperature);
-    SetR("specificEnthalpy", results.specificEnthalpy);
-    SetR("specificEntropy", results.specificEntropy);
-    SetR("quality", results.quality);
-    SetR("specificVolume", results.specificVolume);
+	try {
+        SteamProperties::ThermodynamicQuantity quantity = thermodynamicQuantity();
+        auto const results = SteamProperties(Get("pressure"), quantity, Get("quantityValue")).calculate();
+        SetR("pressure", results.pressure);
+        SetR("temperature", results.temperature);
+        SetR("specificEnthalpy", results.specificEnthalpy);
+        SetR("specificEntropy", results.specificEntropy);
+        SetR("quality", results.quality);
+        SetR("specificVolume", results.specificVolume);
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in steamProperties - ssmt.h: " + what).c_str());
+    }
     info.GetReturnValue().Set(r);
 }
 
@@ -142,38 +147,44 @@ NAN_METHOD(boiler) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+	try {
+        SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
 
-    auto const b = Boiler(Get("deaeratorPressure"), Get("combustionEfficiency"), Get("blowdownRate"), Get("steamPressure"), quantityType, Get("quantityValue"), Get("steamMassFlow"));
+        auto const b = Boiler(Get("deaeratorPressure"), Get("combustionEfficiency"), Get("blowdownRate"),
+                              Get("steamPressure"), quantityType, Get("quantityValue"), Get("steamMassFlow"));
 
-    auto const results = b.getSteamProperties();
-    SetR("steamPressure", results.pressure);
-    SetR("steamTemperature", results.temperature);
-    SetR("steamSpecificEnthalpy", results.specificEnthalpy);
-    SetR("steamSpecificEntropy", results.specificEntropy);
-    SetR("steamQuality", results.quality);
-    SetR("steamMassFlow", results.massFlow);
-    SetR("steamEnergyFlow", results.energyFlow);
+        auto const results = b.getSteamProperties();
+        SetR("steamPressure", results.pressure);
+        SetR("steamTemperature", results.temperature);
+        SetR("steamSpecificEnthalpy", results.specificEnthalpy);
+        SetR("steamSpecificEntropy", results.specificEntropy);
+        SetR("steamQuality", results.quality);
+        SetR("steamMassFlow", results.massFlow);
+        SetR("steamEnergyFlow", results.energyFlow);
 
-    auto const results2 = b.getBlowdownProperties();
-    SetR("blowdownPressure", results2.pressure);
-    SetR("blowdownTemperature", results2.temperature);
-    SetR("blowdownSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("blowdownSpecificEntropy", results2.specificEntropy);
-    SetR("blowdownQuality", results2.quality);
-    SetR("blowdownMassFlow", results2.massFlow);
-    SetR("blowdownEnergyFlow", results2.energyFlow);
+        auto const results2 = b.getBlowdownProperties();
+        SetR("blowdownPressure", results2.pressure);
+        SetR("blowdownTemperature", results2.temperature);
+        SetR("blowdownSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("blowdownSpecificEntropy", results2.specificEntropy);
+        SetR("blowdownQuality", results2.quality);
+        SetR("blowdownMassFlow", results2.massFlow);
+        SetR("blowdownEnergyFlow", results2.energyFlow);
 
-	auto const results3 = b.getFeedwaterProperties();
-    SetR("feedwaterPressure", results3.pressure);
-    SetR("feedwaterTemperature", results3.temperature);
-    SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
-    SetR("feedwaterSpecificEntropy", results3.specificEntropy);
-    SetR("feedwaterQuality", results3.quality);
-    SetR("feedwaterMassFlow", results3.massFlow);
-    SetR("feedwaterEnergyFlow", results3.energyFlow);
-    SetR("boilerEnergy", b.getBoilerEnergy());
-    SetR("fuelEnergy", b.getFuelEnergy());
+        auto const results3 = b.getFeedwaterProperties();
+        SetR("feedwaterPressure", results3.pressure);
+        SetR("feedwaterTemperature", results3.temperature);
+        SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
+        SetR("feedwaterSpecificEntropy", results3.specificEntropy);
+        SetR("feedwaterQuality", results3.quality);
+        SetR("feedwaterMassFlow", results3.massFlow);
+        SetR("feedwaterEnergyFlow", results3.energyFlow);
+        SetR("boilerEnergy", b.getBoilerEnergy());
+        SetR("fuelEnergy", b.getFuelEnergy());
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in boiler - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -182,27 +193,33 @@ NAN_METHOD(heatLoss) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
-    auto const hl = HeatLoss(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("percentHeatLoss"));
-    auto const results = hl.getInletProperties();
+    try {
+        SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+        auto const hl = HeatLoss(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"),
+                                 Get("percentHeatLoss"));
+        auto const results = hl.getInletProperties();
 
-    SetR("inletPressure", results.pressure);
-    SetR("inletTemperature", results.temperature);
-    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
-    SetR("inletSpecificEntropy", results.specificEntropy);
-    SetR("inletQuality", results.quality);
-    SetR("inletMassFlow", results.massFlow);
-    SetR("inletEnergyFlow", results.energyFlow);
+        SetR("inletPressure", results.pressure);
+        SetR("inletTemperature", results.temperature);
+        SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+        SetR("inletSpecificEntropy", results.specificEntropy);
+        SetR("inletQuality", results.quality);
+        SetR("inletMassFlow", results.massFlow);
+        SetR("inletEnergyFlow", results.energyFlow);
 
-    auto const results2 = hl.getOutletProperties();
-    SetR("outletPressure", results2.pressure);
-    SetR("outletTemperature", results2.temperature);
-    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("outletSpecificEntropy", results2.specificEntropy);
-    SetR("outletQuality", results2.quality);
-    SetR("outletMassFlow", results2.massFlow);
-    SetR("outletEnergyFlow", results2.energyFlow);
-    SetR("heatLoss", hl.getHeatLoss());
+        auto const results2 = hl.getOutletProperties();
+        SetR("outletPressure", results2.pressure);
+        SetR("outletTemperature", results2.temperature);
+        SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("outletSpecificEntropy", results2.specificEntropy);
+        SetR("outletQuality", results2.quality);
+        SetR("outletMassFlow", results2.massFlow);
+        SetR("outletEnergyFlow", results2.energyFlow);
+        SetR("heatLoss", hl.getHeatLoss());
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in heatLoss - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -211,36 +228,42 @@ NAN_METHOD(flashTank) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+    try {
+        SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
 
-    auto const ft = FlashTank(Get("inletWaterPressure"), quantityType, Get("quantityValue"), Get("inletWaterMassFlow"), Get("tankPressure"));
+        auto const ft = FlashTank(Get("inletWaterPressure"), quantityType, Get("quantityValue"),
+                                  Get("inletWaterMassFlow"), Get("tankPressure"));
 
-    auto const results = ft.getInletWaterProperties();
-    SetR("inletWaterPressure", results.pressure);
-    SetR("inletWaterTemperature", results.temperature);
-    SetR("inletWaterSpecificEnthalpy", results.specificEnthalpy);
-    SetR("inletWaterSpecificEntropy", results.specificEntropy);
-    SetR("inletWaterQuality", results.quality);
-    SetR("inletWaterMassFlow", results.massFlow);
-    SetR("inletWaterEnergyFlow", results.energyFlow);
+        auto const results = ft.getInletWaterProperties();
+        SetR("inletWaterPressure", results.pressure);
+        SetR("inletWaterTemperature", results.temperature);
+        SetR("inletWaterSpecificEnthalpy", results.specificEnthalpy);
+        SetR("inletWaterSpecificEntropy", results.specificEntropy);
+        SetR("inletWaterQuality", results.quality);
+        SetR("inletWaterMassFlow", results.massFlow);
+        SetR("inletWaterEnergyFlow", results.energyFlow);
 
-    auto const results2 = ft.getOutletGasSaturatedProperties();
-    SetR("outletGasPressure", results2.pressure);
-    SetR("outletGasTemperature", results2.temperature);
-    SetR("outletGasSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("outletGasSpecificEntropy", results2.specificEntropy);
-    SetR("outletGasQuality", 1);
-    SetR("outletGasMassFlow", results2.massFlow);
-    SetR("outletGasEnergyFlow", results2.energyFlow);
+        auto const results2 = ft.getOutletGasSaturatedProperties();
+        SetR("outletGasPressure", results2.pressure);
+        SetR("outletGasTemperature", results2.temperature);
+        SetR("outletGasSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("outletGasSpecificEntropy", results2.specificEntropy);
+        SetR("outletGasQuality", 1);
+        SetR("outletGasMassFlow", results2.massFlow);
+        SetR("outletGasEnergyFlow", results2.energyFlow);
 
-    auto const results3 = ft.getOutletLiquidSaturatedProperties();
-    SetR("outletLiquidPressure", results3.pressure);
-    SetR("outletLiquidTemperature", results3.temperature);
-    SetR("outletLiquidSpecificEnthalpy", results3.specificEnthalpy);
-    SetR("outletLiquidSpecificEntropy", results3.specificEntropy);
-    SetR("outletLiquidQuality", 0);
-    SetR("outletLiquidMassFlow", results3.massFlow);
-    SetR("outletLiquidEnergyFlow", results3.energyFlow);
+        auto const results3 = ft.getOutletLiquidSaturatedProperties();
+        SetR("outletLiquidPressure", results3.pressure);
+        SetR("outletLiquidTemperature", results3.temperature);
+        SetR("outletLiquidSpecificEnthalpy", results3.specificEnthalpy);
+        SetR("outletLiquidSpecificEntropy", results3.specificEntropy);
+        SetR("outletLiquidQuality", 0);
+        SetR("outletLiquidMassFlow", results3.massFlow);
+        SetR("outletLiquidEnergyFlow", results3.energyFlow);
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in flashTank - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -249,26 +272,32 @@ NAN_METHOD(prvWithoutDesuperheating) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
-    auto const pwod = PrvWithoutDesuperheating(Get("inletPressure"),quantityType, Get("quantityValue"), Get("inletMassFlow"), Get("outletPressure"));
+    try {
+        SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+        auto const pwod = PrvWithoutDesuperheating(Get("inletPressure"), quantityType, Get("quantityValue"),
+                                                   Get("inletMassFlow"), Get("outletPressure"));
 
-    auto const results = pwod.getInletProperties();
-    SetR("inletPressure", results.pressure);
-    SetR("inletTemperature", results.temperature);
-    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
-    SetR("inletSpecificEntropy", results.specificEntropy);
-    SetR("inletQuality", results.quality);
-    SetR("inletMassFlow", pwod.getInletMassFlow());
-    SetR("inletEnergyFlow", pwod.getInletEnergyFlow());
+        auto const results = pwod.getInletProperties();
+        SetR("inletPressure", results.pressure);
+        SetR("inletTemperature", results.temperature);
+        SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+        SetR("inletSpecificEntropy", results.specificEntropy);
+        SetR("inletQuality", results.quality);
+        SetR("inletMassFlow", pwod.getInletMassFlow());
+        SetR("inletEnergyFlow", pwod.getInletEnergyFlow());
 
-    auto const results2 = pwod.getOutletProperties();
-    SetR("outletPressure", results2.pressure);
-    SetR("outletTemperature", results2.temperature);
-    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("outletSpecificEntropy", results2.specificEntropy);
-    SetR("outletQuality", results2.quality);
-    SetR("outletMassFlow", pwod.getOutletMassFlow());
-    SetR("outletEnergyFlow", pwod.getOutletEnergyFlow());
+        auto const results2 = pwod.getOutletProperties();
+        SetR("outletPressure", results2.pressure);
+        SetR("outletTemperature", results2.temperature);
+        SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("outletSpecificEntropy", results2.specificEntropy);
+        SetR("outletQuality", results2.quality);
+        SetR("outletMassFlow", pwod.getOutletMassFlow());
+        SetR("outletEnergyFlow", pwod.getOutletEnergyFlow());
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in prvWithoutDesuperheating - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -278,39 +307,45 @@ NAN_METHOD(prvWithDesuperheating) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
-    SteamProperties::ThermodynamicQuantity feedwaterQuantityType = feedwaterThermodynamicQuantity();
+    try {
+        SteamProperties::ThermodynamicQuantity quantityType = thermodynamicQuantity();
+        SteamProperties::ThermodynamicQuantity feedwaterQuantityType = feedwaterThermodynamicQuantity();
 
-    auto const pwd = PrvWithDesuperheating(Get("inletPressure"), quantityType, Get("quantityValue"), Get("inletMassFlow"),
-                                           Get("outletPressure"), Get("feedwaterPressure"), feedwaterQuantityType,
-                                           Get("feedwaterQuantityValue"), Get("desuperheatingTemp"));
+        auto const pwd = PrvWithDesuperheating(Get("inletPressure"), quantityType, Get("quantityValue"),
+                                               Get("inletMassFlow"),
+                                               Get("outletPressure"), Get("feedwaterPressure"), feedwaterQuantityType,
+                                               Get("feedwaterQuantityValue"), Get("desuperheatingTemp"));
 
-    auto const results = pwd.getInletProperties();
-    SetR("inletPressure", results.pressure);
-    SetR("inletTemperature", results.temperature);
-    SetR("inletSpecificEnthalpy", results.specificEnthalpy);
-    SetR("inletSpecificEntropy", results.specificEntropy);
-    SetR("inletQuality", results.quality);
-    SetR("inletMassFlow", pwd.getInletMassFlow());
-    SetR("inletEnergyFlow", pwd.getInletEnergyFlow());
+        auto const results = pwd.getInletProperties();
+        SetR("inletPressure", results.pressure);
+        SetR("inletTemperature", results.temperature);
+        SetR("inletSpecificEnthalpy", results.specificEnthalpy);
+        SetR("inletSpecificEntropy", results.specificEntropy);
+        SetR("inletQuality", results.quality);
+        SetR("inletMassFlow", pwd.getInletMassFlow());
+        SetR("inletEnergyFlow", pwd.getInletEnergyFlow());
 
-    auto const results2 = pwd.getOutletProperties();
-    SetR("outletPressure", results2.pressure);
-    SetR("outletTemperature", results2.temperature);
-    SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("outletSpecificEntropy", results2.specificEntropy);
-    SetR("outletQuality", results2.quality);
-    SetR("outletMassFlow", pwd.getOutletMassFlow());
-    SetR("outletEnergyFlow", pwd.getOutletEnergyFlow());
+        auto const results2 = pwd.getOutletProperties();
+        SetR("outletPressure", results2.pressure);
+        SetR("outletTemperature", results2.temperature);
+        SetR("outletSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("outletSpecificEntropy", results2.specificEntropy);
+        SetR("outletQuality", results2.quality);
+        SetR("outletMassFlow", pwd.getOutletMassFlow());
+        SetR("outletEnergyFlow", pwd.getOutletEnergyFlow());
 
-    auto const results3 = pwd.getFeedwaterProperties();
-    SetR("feedwaterPressure", results3.pressure);
-    SetR("feedwaterTemperature", results3.temperature);
-    SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
-    SetR("feedwaterSpecificEntropy", results3.specificEntropy);
-    SetR("feedwaterQuality", results3.quality);
-    SetR("feedwaterMassFlow", pwd.getFeedwaterMassFlow());
-    SetR("feedwaterEnergyFlow", pwd.getFeedwaterEnergyFlow());
+        auto const results3 = pwd.getFeedwaterProperties();
+        SetR("feedwaterPressure", results3.pressure);
+        SetR("feedwaterTemperature", results3.temperature);
+        SetR("feedwaterSpecificEnthalpy", results3.specificEnthalpy);
+        SetR("feedwaterSpecificEntropy", results3.specificEntropy);
+        SetR("feedwaterQuality", results3.quality);
+        SetR("feedwaterMassFlow", pwd.getFeedwaterMassFlow());
+        SetR("feedwaterEnergyFlow", pwd.getFeedwaterEnergyFlow());
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in prvWithDesuperheating - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -319,48 +354,53 @@ NAN_METHOD(deaerator) {
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 
-    SteamProperties::ThermodynamicQuantity waterQuantityType = waterThermodynamicQuantity();
-    SteamProperties::ThermodynamicQuantity steamQuantityType = steamThermodynamicQuantity();
+    try {
+        SteamProperties::ThermodynamicQuantity waterQuantityType = waterThermodynamicQuantity();
+        SteamProperties::ThermodynamicQuantity steamQuantityType = steamThermodynamicQuantity();
 
-    Deaerator d(Get("deaeratorPressure"), Get("ventRate"), Get("feedwaterMassFlow"), Get("waterPressure"),
-                waterQuantityType, Get("waterQuantityValue"), Get("steamPressure"), steamQuantityType,
-                Get("steamQuantityValue"));
+        Deaerator d(Get("deaeratorPressure"), Get("ventRate"), Get("feedwaterMassFlow"), Get("waterPressure"),
+                    waterQuantityType, Get("waterQuantityValue"), Get("steamPressure"), steamQuantityType,
+                    Get("steamQuantityValue"));
 
-    auto const results = d.getFeedwaterProperties();
-    SetR("feedwaterPressure", results.pressure);
-    SetR("feedwaterTemperature", results.temperature);
-    SetR("feedwaterSpecificEnthalpy", results.specificEnthalpy);
-    SetR("feedwaterSpecificEntropy", results.specificEntropy);
-    SetR("feedwaterQuality", results.quality);
-    SetR("feedwaterMassFlow", results.massFlow);
-    SetR("feedwaterEnergyFlow", results.energyFlow);
+        auto const results = d.getFeedwaterProperties();
+        SetR("feedwaterPressure", results.pressure);
+        SetR("feedwaterTemperature", results.temperature);
+        SetR("feedwaterSpecificEnthalpy", results.specificEnthalpy);
+        SetR("feedwaterSpecificEntropy", results.specificEntropy);
+        SetR("feedwaterQuality", results.quality);
+        SetR("feedwaterMassFlow", results.massFlow);
+        SetR("feedwaterEnergyFlow", results.energyFlow);
 
-    auto const results2 = d.getVentedSteamProperties();
-    SetR("ventedSteamPressure", results2.pressure);
-    SetR("ventedSteamTemperature", results2.temperature);
-    SetR("ventedSteamSpecificEnthalpy", results2.specificEnthalpy);
-    SetR("ventedSteamSpecificEntropy", results2.specificEntropy);
-    SetR("ventedSteamQuality", results2.quality);
-    SetR("ventedSteamMassFlow", results2.massFlow);
-    SetR("ventedSteamEnergyFlow", results2.energyFlow);
+        auto const results2 = d.getVentedSteamProperties();
+        SetR("ventedSteamPressure", results2.pressure);
+        SetR("ventedSteamTemperature", results2.temperature);
+        SetR("ventedSteamSpecificEnthalpy", results2.specificEnthalpy);
+        SetR("ventedSteamSpecificEntropy", results2.specificEntropy);
+        SetR("ventedSteamQuality", results2.quality);
+        SetR("ventedSteamMassFlow", results2.massFlow);
+        SetR("ventedSteamEnergyFlow", results2.energyFlow);
 
-    auto const results3 = d.getInletWaterProperties();
-    SetR("inletWaterPressure", results3.pressure);
-    SetR("inletWaterTemperature", results3.temperature);
-    SetR("inletWaterSpecificEnthalpy", results3.specificEnthalpy);
-    SetR("inletWaterSpecificEntropy", results3.specificEntropy);
-    SetR("inletWaterQuality", results3.quality);
-    SetR("inletWaterMassFlow", results3.massFlow);
-    SetR("inletWaterEnergyFlow", results3.energyFlow);
+        auto const results3 = d.getInletWaterProperties();
+        SetR("inletWaterPressure", results3.pressure);
+        SetR("inletWaterTemperature", results3.temperature);
+        SetR("inletWaterSpecificEnthalpy", results3.specificEnthalpy);
+        SetR("inletWaterSpecificEntropy", results3.specificEntropy);
+        SetR("inletWaterQuality", results3.quality);
+        SetR("inletWaterMassFlow", results3.massFlow);
+        SetR("inletWaterEnergyFlow", results3.energyFlow);
 
-    auto const results4 = d.getInletSteamProperties();
-    SetR("inletSteamPressure", results4.pressure);
-    SetR("inletSteamTemperature", results4.temperature);
-    SetR("inletSteamSpecificEnthalpy", results4.specificEnthalpy);
-    SetR("inletSteamSpecificEntropy", results4.specificEntropy);
-    SetR("inletSteamQuality", results4.quality);
-    SetR("inletSteamMassFlow", results4.massFlow);
-    SetR("inletSteamEnergyFlow", results4.energyFlow);
+        auto const results4 = d.getInletSteamProperties();
+        SetR("inletSteamPressure", results4.pressure);
+        SetR("inletSteamTemperature", results4.temperature);
+        SetR("inletSteamSpecificEnthalpy", results4.specificEnthalpy);
+        SetR("inletSteamSpecificEntropy", results4.specificEntropy);
+        SetR("inletSteamQuality", results4.quality);
+        SetR("inletSteamMassFlow", results4.massFlow);
+        SetR("inletSteamEnergyFlow", results4.energyFlow);
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in deaerator - ssmt.h: " + what).c_str());
+    }
 
     info.GetReturnValue().Set(r);
 }
@@ -408,22 +448,27 @@ NAN_METHOD(header) {
         Nan::Set(r, inletNum, obj);
     }
 
-	auto header = Header(headerPressure, inlets);
-    Local<String> headerStr = Nan::New<String>("header").ToLocalChecked();
+    try {
+        auto header = Header(headerPressure, inlets);
+        Local <String> headerStr = Nan::New<String>("header").ToLocalChecked();
 
-    auto const headerProps = header.getHeaderProperties();
+        auto const headerProps = header.getHeaderProperties();
 
-    Local<Object> obj = Nan::New<Object>();
+        Local <Object> obj = Nan::New<Object>();
 
-    Nan::Set(obj, pressureStr, Nan::New<Number>(header.getHeaderPressure()));
-    Nan::Set(obj, temperatureStr, Nan::New<Number>(headerProps.temperature));
-    Nan::Set(obj, qualityStr, Nan::New<Number>(headerProps.quality));
-    Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(headerProps.specificEnthalpy));
-    Nan::Set(obj, specificEntropyStr, Nan::New<Number>(headerProps.specificEntropy));
-    Nan::Set(obj, energyFlowStr, Nan::New<Number>(header.getInletEnergyFlow()));
-    Nan::Set(obj, massFlowStr, Nan::New<Number>(header.getInletMassFlow()));
+        Nan::Set(obj, pressureStr, Nan::New<Number>(header.getHeaderPressure()));
+        Nan::Set(obj, temperatureStr, Nan::New<Number>(headerProps.temperature));
+        Nan::Set(obj, qualityStr, Nan::New<Number>(headerProps.quality));
+        Nan::Set(obj, specificEnthalpyStr, Nan::New<Number>(headerProps.specificEnthalpy));
+        Nan::Set(obj, specificEntropyStr, Nan::New<Number>(headerProps.specificEntropy));
+        Nan::Set(obj, energyFlowStr, Nan::New<Number>(header.getInletEnergyFlow()));
+        Nan::Set(obj, massFlowStr, Nan::New<Number>(header.getInletMassFlow()));
 
-    Nan::Set(r, headerStr, obj);
+        Nan::Set(r, headerStr, obj);
+    } catch (std::runtime_error const & e) {
+        std::string const what = e.what();
+        ThrowError(std::string("std::runtime_error thrown in header - ssmt.h: " + what).c_str());
+    }
     info.GetReturnValue().Set(r);
 }
 

--- a/include/ssmt/Boiler.h
+++ b/include/ssmt/Boiler.h
@@ -38,7 +38,7 @@ public:
     Boiler(double deaeratorPressure, double combustionEfficiency, double blowdownRate, double steamPressure,
            SteamProperties::ThermodynamicQuantity quantityType, double quantityValue, double steamMassFlow);
 
-    SteamSystemModelerTool::SteamPropertiesOutput const & getSteamProperties() const { return steamProperties; }
+    SteamSystemModelerTool::FluidProperties const & getSteamProperties() const { return steamProperties; }
 
     SteamSystemModelerTool::FluidProperties const & getBlowdownProperties() const { return blowdownProperties; }
 

--- a/include/ssmt/Boiler.h
+++ b/include/ssmt/Boiler.h
@@ -38,7 +38,7 @@ public:
     Boiler(double deaeratorPressure, double combustionEfficiency, double blowdownRate, double steamPressure,
            SteamProperties::ThermodynamicQuantity quantityType, double quantityValue, double steamMassFlow);
 
-    SteamProperties::Output const & getSteamProperties() const { return steamProperties; }
+    SteamSystemModelerTool::SteamPropertiesOutput const & getSteamProperties() const { return steamProperties; }
 
     SteamSystemModelerTool::FluidProperties const & getBlowdownProperties() const { return blowdownProperties; }
 

--- a/include/ssmt/Boiler.h
+++ b/include/ssmt/Boiler.h
@@ -10,6 +10,7 @@
  */
 
 #include "SteamProperties.h"
+#include "SteamSystemModelerTool.h"
 
 #ifndef AMO_TOOLS_SUITE_BOILER_H
 #define AMO_TOOLS_SUITE_BOILER_H
@@ -33,16 +34,15 @@ public:
      * @param quantityValue double, value of the quantity (either temperature in K, enthalpy in kJ/kg, entropy in kJ/kg/K, or quality - unitless)
      * @param steamMassFlow double, steam mass flow in kg/hr
      *
-     *
      * */
     Boiler(double deaeratorPressure, double combustionEfficiency, double blowdownRate, double steamPressure,
            SteamProperties::ThermodynamicQuantity quantityType, double quantityValue, double steamMassFlow);
 
-    std::unordered_map <std::string, double> const & getSteamProperties() const { return steamProperties; }
+    SteamProperties::Output const & getSteamProperties() const { return steamProperties; }
 
-    std::unordered_map <std::string, double> const & getBlowdownProperties() const { return blowdownProperties; }
+    SteamSystemModelerTool::FluidProperties const & getBlowdownProperties() const { return blowdownProperties; }
 
-    std::unordered_map <std::string, double> const & getFeedwaterProperties() const { return feedwaterProperties; }
+    SteamSystemModelerTool::FluidProperties const & getFeedwaterProperties() const { return feedwaterProperties; }
 
     /**
 	 * Gets the deaerator pressure
@@ -148,9 +148,7 @@ private:
     SteamProperties::ThermodynamicQuantity quantityType;
     double quantityValue, steamMassFlow;
 
-    std::unordered_map <std::string, double> steamProperties;
-    std::unordered_map <std::string, double> blowdownProperties;
-    std::unordered_map <std::string, double> feedwaterProperties;
+    SteamSystemModelerTool::FluidProperties steamProperties, blowdownProperties, feedwaterProperties;
     double boilerEnergy, fuelEnergy;
 };
 

--- a/include/ssmt/Deaerator.h
+++ b/include/ssmt/Deaerator.h
@@ -44,27 +44,27 @@ public:
 
 	/**
      * Gets all of the feedwater properties
-     * @return std::unordered_map <std::string, double>, feedwater properties
+     * @return SteamSystemModelerTool::FluidProperties feedwater properties
      */
-	std::unordered_map<std::string, double> const & getFeedwaterProperties() const { return feedwaterProperties; }
+	SteamSystemModelerTool::FluidProperties const & getFeedwaterProperties() const { return feedwaterProperties; }
 
 	/**
      * Gets all of the vented steam properties
-     * @return std::unordered_map <std::string, double>, vented steam properties
+     * @return SteamSystemModelerTool::FluidProperties, vented steam properties
      */
-    std::unordered_map<std::string, double> const & getVentedSteamProperties() const { return ventedSteamProperties; }
+	SteamSystemModelerTool::FluidProperties const & getVentedSteamProperties() const { return ventedSteamProperties; }
 
 	/**
      * Gets all of the inlet water properties
-     * @return std::unordered_map <std::string, double>, inlet water properties
+     * @return SteamSystemModelerTool::FluidProperties, inlet water properties
      */
-    std::unordered_map<std::string, double> const & getInletWaterProperties() const { return inletWaterProperties; }
+	SteamSystemModelerTool::FluidProperties const & getInletWaterProperties() const { return inletWaterProperties; }
 
 	/**
      * Gets all of the inlet steam properties
-     * @return std::unordered_map <std::string, double>, inlet steam properties
+     * @return SteamSystemModelerTool::FluidProperties, inlet steam properties
      */
-    std::unordered_map<std::string, double> const & getInletSteamProperties() const { return inletSteamProperties; }
+	SteamSystemModelerTool::FluidProperties const & getInletSteamProperties() const { return inletSteamProperties; }
 
 	/**
      * Gets the deaerator pressure
@@ -183,8 +183,8 @@ private:
     double steamPressure, steamQuantityValue;
     SteamProperties::ThermodynamicQuantity waterQuantityType, steamQuantityType;
 
-    std::unordered_map <std::string, double> feedwaterProperties, ventedSteamProperties, inletWaterProperties;
-    std::unordered_map <std::string, double> inletSteamProperties;
+	SteamSystemModelerTool::FluidProperties feedwaterProperties, ventedSteamProperties, inletWaterProperties;
+	SteamSystemModelerTool::FluidProperties inletSteamProperties;
 };
 
 #endif //AMO_TOOLS_SUITE_DEAERATOR_H

--- a/include/ssmt/FlashTank.h
+++ b/include/ssmt/FlashTank.h
@@ -116,7 +116,6 @@ private:
     SteamProperties::ThermodynamicQuantity quantityType;
 
     SteamSystemModelerTool::FluidProperties inletWaterProperties, outletLiquidSaturatedProperties, outletGasSaturatedProperties;
-//	std::unordered_map <std::string, double> inletWaterProperties, outletSaturatedProperties;
 };
 
 

--- a/include/ssmt/FlashTank.h
+++ b/include/ssmt/FlashTank.h
@@ -11,6 +11,7 @@
 
 #include "SteamProperties.h"
 #include "SaturatedProperties.h"
+#include "SteamSystemModelerTool.h"
 
 #ifndef AMO_TOOLS_SUITE_FLASHTANK_H
 #define AMO_TOOLS_SUITE_FLASHTANK_H
@@ -22,7 +23,6 @@
 class FlashTank {
 public:
     /**
-     *
      * Constructor for the flash tank calculator
      *
      * @param inletWaterPressure double, inlet water pressure in MPa
@@ -31,7 +31,6 @@ public:
      * @param inletWaterMassFlow double, inlet water mass flow in kg/hr
      * @param tankPressure double, pressure of the tank in MPa
      *
-     *
      * */
     FlashTank(double inletWaterPressure, SteamProperties::ThermodynamicQuantity quantityType, double quantityValue,
               double inletWaterMassFlow, double tankPressure);
@@ -39,15 +38,16 @@ public:
 
     /**
      * Gets all of the properties of the inlet water
-     * @return std::unordered_map <std::string, double>, inlet water properties
+     * @return SteamSystemModelerTool::FluidProperties, inlet water properties
      */
-    std::unordered_map <std::string, double> const & getInletWaterProperties() const { return inletWaterProperties; };
+    SteamSystemModelerTool::FluidProperties const & getInletWaterProperties() const { return inletWaterProperties; };
 
     /**
      * Gets all of the saturated properties of the outlet gas and liquid
-     * @return std::unordered_map <std::string, double>, outlet gas and liquid saturated properties
+     * @return SteamSystemModelerTool::FluidProperties, outlet gas and liquid saturated properties
      */
-    std::unordered_map <std::string, double> const & getOutletSaturatedProperties() const { return outletSaturatedProperties; }
+    SteamSystemModelerTool::FluidProperties const & getOutletGasSaturatedProperties() const { return outletGasSaturatedProperties; }
+	SteamSystemModelerTool::FluidProperties const & getOutletLiquidSaturatedProperties() const { return outletLiquidSaturatedProperties; }
 
 	/**
      * Gets the inlet water pressure
@@ -115,7 +115,8 @@ private:
     double inletWaterPressure, quantityValue, inletWaterMassFlow, tankPressure;
     SteamProperties::ThermodynamicQuantity quantityType;
 
-    std::unordered_map <std::string, double> inletWaterProperties, outletSaturatedProperties;
+    SteamSystemModelerTool::FluidProperties inletWaterProperties, outletLiquidSaturatedProperties, outletGasSaturatedProperties;
+//	std::unordered_map <std::string, double> inletWaterProperties, outletSaturatedProperties;
 };
 
 

--- a/include/ssmt/Header.h
+++ b/include/ssmt/Header.h
@@ -2,7 +2,6 @@
 #define AMO_TOOLS_SUITE_HEADER_H
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 #include "SteamProperties.h"
 
@@ -23,7 +22,7 @@ public:
 	double getMassFlow() const { return massFlow; }
 	SteamProperties::ThermodynamicQuantity getQuantityType() const { return quantityType; }
 	double getInletEnergyFlow() const { return  inletEnergyFlow; }
-	std::unordered_map<std::string, double> const & getInletProperties() const { return inletProperties; }
+	SteamSystemModelerTool::SteamPropertiesOutput const & getInletProperties() const { return inletProperties; }
 
 	void setPressure(double pressure);
 	void setQuantityValue(double quantityValue);
@@ -36,7 +35,7 @@ private:
 	double pressure, quantityValue, massFlow;
 	SteamProperties::ThermodynamicQuantity quantityType;
 	double inletEnergyFlow;
-	std::unordered_map<std::string, double> inletProperties;
+	SteamSystemModelerTool::SteamPropertiesOutput inletProperties;
 };
 
 class Header {
@@ -76,8 +75,8 @@ public:
 
 	/**
      * Gets the Header properties
-     * @return std::unordered_map<std::string, double> const &, header properties */
-	std::unordered_map<std::string, double> const & getHeaderProperties() const { return headerProperties; }
+     * @return SteamSystemModelerTool::SteamPropertiesOutput const &, header properties */
+	SteamSystemModelerTool::SteamPropertiesOutput const & getHeaderProperties() const { return headerProperties; }
 
 	/**
      * Sets the Header pressure - units of MPa
@@ -93,7 +92,7 @@ private:
 	void calculate();
 	double headerPressure, specificEnthalpy, inletEnergyFlow, inletMassFlow;
 	std::vector<Inlet> inlets;
-	std::unordered_map<std::string, double> headerProperties;
+	SteamSystemModelerTool::SteamPropertiesOutput headerProperties;
 };
 
 #endif //AMO_TOOLS_SUITE_HEADER_H

--- a/include/ssmt/HeatLoss.h
+++ b/include/ssmt/HeatLoss.h
@@ -22,7 +22,6 @@
 class HeatLoss {
 public:
     /**
-     *
      * Constructor for the heat loss calculator
      *
      * @param inletPressure double, inlet pressure in MPa
@@ -31,20 +30,19 @@ public:
      * @param inletMassFlow double, inlet mass flow in kg/hr
      * @param percentHeatLoss double, heat loss as %
      *
-     *
      * */
     HeatLoss(double inletPressure, SteamProperties::ThermodynamicQuantity quantityType, double quantityValue,
              double inletMassFlow, double percentHeatLoss);
 
     /**
      * Gets all of the inlet properties
-     * @return std::unordered_map <std::string, double>, inlet properties
+     * @return SteamSystemModelerTool::FluidProperties, inlet properties
      */
     SteamSystemModelerTool::FluidProperties const & getInletProperties() const { return inletProperties; };
 
     /**
      * Gets all of the outlet steam properties
-     * @return std::unordered_map <std::string, double>, outlet steam properties
+     * @return SteamSystemModelerTool::FluidProperties, outlet steam properties
      */
     SteamSystemModelerTool::FluidProperties const & getOutletProperties() const { return outletProperties; };
 

--- a/include/ssmt/HeatLoss.h
+++ b/include/ssmt/HeatLoss.h
@@ -10,6 +10,7 @@
  */
 
 #include "SteamProperties.h"
+#include "SteamSystemModelerTool.h"
 
 #ifndef AMO_TOOLS_SUITE_HEATLOSS_H
 #define AMO_TOOLS_SUITE_HEATLOSS_H
@@ -39,13 +40,13 @@ public:
      * Gets all of the inlet properties
      * @return std::unordered_map <std::string, double>, inlet properties
      */
-    std::unordered_map <std::string, double> const & getInletProperties() const { return inletProperties; };
+    SteamSystemModelerTool::FluidProperties const & getInletProperties() const { return inletProperties; };
 
     /**
      * Gets all of the outlet steam properties
      * @return std::unordered_map <std::string, double>, outlet steam properties
      */
-    std::unordered_map <std::string, double> const & getOutletProperties() const { return outletProperties; };
+    SteamSystemModelerTool::FluidProperties const & getOutletProperties() const { return outletProperties; };
 
     /**
      * Gets the heat loss
@@ -117,9 +118,9 @@ private:
     void calculateProperties();
 
     double inletPressure, quantityValue, inletMassFlow, percentHeatLoss;
-    std::unordered_map <std::string, double> inletProperties;
+    SteamSystemModelerTool::FluidProperties inletProperties;
     double inletEnergyFlow, outletEnergyFlow;
-    std::unordered_map <std::string, double> outletProperties;
+    SteamSystemModelerTool::FluidProperties outletProperties;
 
     double heatLoss;
     SteamProperties::ThermodynamicQuantity quantityType;

--- a/include/ssmt/PRV.h
+++ b/include/ssmt/PRV.h
@@ -78,13 +78,13 @@ public:
 
     /**
      * Gets all of the properties of the inlet steam
-     * @return std::unordered_map <std::string, double>, inlet steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput , inlet steam properties
      */
     SteamSystemModelerTool::SteamPropertiesOutput const & getInletProperties() const { return inletProperties; };
 
     /**
      * Gets all of the properties of the outlet steam
-     * @return std::unordered_map <std::string, double>, outlet steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput , outlet steam properties
      */
     SteamSystemModelerTool::SteamPropertiesOutput const & getOutletProperties() const { return outletProperties; };
 

--- a/include/ssmt/PRV.h
+++ b/include/ssmt/PRV.h
@@ -424,7 +424,6 @@ private:
 
     // Out values
     SteamSystemModelerTool::SteamPropertiesOutput inletProperties, outletProperties, feedwaterProperties;
-//    std::unordered_map <std::string, double> inletProperties, outletProperties, feedwaterProperties;
     double inletEnergyFlow, outletMassFlow, outletEnergyFlow, feedwaterMassFlow, feedwaterEnergyFlow;
 };
 

--- a/include/ssmt/PRV.h
+++ b/include/ssmt/PRV.h
@@ -80,13 +80,13 @@ public:
      * Gets all of the properties of the inlet steam
      * @return std::unordered_map <std::string, double>, inlet steam properties
      */
-    std::unordered_map <std::string, double> const & getInletProperties() const { return inletProperties; };
+    SteamSystemModelerTool::SteamPropertiesOutput const & getInletProperties() const { return inletProperties; };
 
     /**
      * Gets all of the properties of the outlet steam
      * @return std::unordered_map <std::string, double>, outlet steam properties
      */
-    std::unordered_map <std::string, double> const & getOutletProperties() const { return outletProperties; };
+    SteamSystemModelerTool::SteamPropertiesOutput const & getOutletProperties() const { return outletProperties; };
 
     /**
      * Gets the inlet energy flow
@@ -166,7 +166,7 @@ private:
     double inletPressure, quantityValue, inletMassFlow, outletPressure, inletEnergyFlow;
     SteamProperties::ThermodynamicQuantity quantityType;
 
-    std::unordered_map <std::string, double> inletProperties, outletProperties;
+    SteamSystemModelerTool::SteamPropertiesOutput inletProperties, outletProperties;
 };
 
 
@@ -368,21 +368,21 @@ public:
 
     /**
      * Gets all of the properties of the inlet steam
-     * @return std::unordered_map <std::string, double>, inlet steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, inlet steam properties
      */
-    std::unordered_map <std::string, double> const & getInletProperties() const { return inletProperties; };
+    SteamSystemModelerTool::SteamPropertiesOutput const & getInletProperties() const { return inletProperties; };
 
     /**
      * Gets all of the properties of the outlet steam
-     * @return std::unordered_map <std::string, double>, outlet steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, outlet steam properties
      */
-    std::unordered_map <std::string, double> const & getOutletProperties() const { return outletProperties; };
+    SteamSystemModelerTool::SteamPropertiesOutput const & getOutletProperties() const { return outletProperties; };
 
     /**
      * Gets all of the properties of the feedwater steam
-     * @return std::unordered_map <std::string, double>, feedwater steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, feedwater steam properties
      */
-    std::unordered_map <std::string, double> const & getFeedwaterProperties() const { return feedwaterProperties; };
+    SteamSystemModelerTool::SteamPropertiesOutput const & getFeedwaterProperties() const { return feedwaterProperties; };
 
     /**
      * Gets the inlet energy flow
@@ -423,7 +423,8 @@ private:
     SteamProperties::ThermodynamicQuantity quantityType, feedwaterQuantityType;
 
     // Out values
-    std::unordered_map <std::string, double> inletProperties, outletProperties, feedwaterProperties;
+    SteamSystemModelerTool::SteamPropertiesOutput inletProperties, outletProperties, feedwaterProperties;
+//    std::unordered_map <std::string, double> inletProperties, outletProperties, feedwaterProperties;
     double inletEnergyFlow, outletMassFlow, outletEnergyFlow, feedwaterMassFlow, feedwaterEnergyFlow;
 };
 

--- a/include/ssmt/SaturatedProperties.h
+++ b/include/ssmt/SaturatedProperties.h
@@ -9,11 +9,10 @@
  *
  */
 
-#include <unordered_map>
-#include <string>
-
 #ifndef AMO_TOOLS_SUITE_SATURATEDPROPERTIES_H
 #define AMO_TOOLS_SUITE_SATURATEDPROPERTIES_H
+
+#include "SteamSystemModelerTool.h"
 
 /**
  * Saturated temperature class
@@ -26,7 +25,7 @@ public:
      * @param saturatedPressure double, saturated pressure in MPa
      * */
     explicit SaturatedTemperature(double saturatedPressure)
-            : saturatedPressure_(saturatedPressure) {}
+            : saturatedPressure(saturatedPressure) {}
     /**
      * Calculates the saturated temperature
      * @return double, saturated temperature in Kelvin
@@ -34,7 +33,7 @@ public:
     double calculate() const;
 
 private:
-    const double saturatedPressure_;
+    const double saturatedPressure;
 };
 
 
@@ -48,7 +47,7 @@ public:
      * Constructor for the saturated pressure calculator
      * @param saturatedTemperature double, saturated temperature in Kelvin
      * */
-    explicit SaturatedPressure(double saturatedTemperature) : saturatedTemperature_(saturatedTemperature) {}
+    explicit SaturatedPressure(double saturatedTemperature) : saturatedTemperature(saturatedTemperature) {}
 
     /**
      * Calculates the saturated pressure
@@ -57,7 +56,7 @@ public:
     double calculate() const;
 
 private:
-    const double saturatedTemperature_;
+    const double saturatedTemperature;
 };
 
 
@@ -74,13 +73,13 @@ public:
      * @param saturatedTemperature double, saturated temperature in Kelvin
      * */
     SaturatedProperties(double saturatedPressure, double saturatedTemperature)
-            : saturatedPressure_(saturatedPressure),
-              saturatedTemperature_(saturatedTemperature) {}
+            : saturatedPressure(saturatedPressure),
+              saturatedTemperature(saturatedTemperature) {}
 
-    std::unordered_map<std::string, double> calculate();
+    SteamSystemModelerTool::SaturatedPropertiesOutput calculate();
 
 private:
-    const double saturatedPressure_, saturatedTemperature_;
+    const double saturatedPressure, saturatedTemperature;
 };
 
 

--- a/include/ssmt/SteamProperties.h
+++ b/include/ssmt/SteamProperties.h
@@ -1,38 +1,13 @@
-#include <unordered_map>
-#include <string>
-
 #ifndef AMO_TOOLS_SUITE_STEAMPROPERTIES_H
 #define AMO_TOOLS_SUITE_STEAMPROPERTIES_H
 
+#include <string>
+#include "SteamSystemModelerTool.h"
+
+class SteamSystemModelerTool;
+
 class SteamProperties {
 public:
-	/**
-	 * SteamProperties::Output contains the properties of steam
-	 * @param temperature in Kelvin
-	 * @param pressure in MPa
-	 * @param quality - unitless
-	 * @param specificVolume in m³/kg
-	 * @param density in kg/m³
-	 * @param specificEnthalpy in kJ/kg
-	 * @param specificEntropy in kJ/kg/K
-	 * @param internalEnergy - optional parameter - in MJ
-	 */
-	struct Output {
-		Output(const double temperature, const double pressure, const double quality,
-		       const double specificVolume, const double density, const double specificEnthalpy,
-		       const double specificEntropy, const double internalEnergy = 0):
-				temperature(temperature), pressure(pressure), quality(quality), specificVolume(specificVolume),
-				density(density), specificEnthalpy(specificEnthalpy), specificEntropy(specificEntropy),
-				internalEnergy(internalEnergy)
-		{}
-
-		Output():
-				temperature(0), pressure(0), quality(0), specificVolume(0), density(0),
-				specificEnthalpy(0), specificEntropy(0), internalEnergy(0)
-		{}
-
-		double temperature, pressure, quality, specificVolume, density, specificEnthalpy, specificEntropy, internalEnergy;
-	};
 
     ///enum class for ThermodynamicQuantity
 	enum class ThermodynamicQuantity {
@@ -59,42 +34,42 @@ public:
      * @param pressure double, pressure in MPa
      * @param quantityValue ThermodynamicQuantity, the type of value that will be used to calculate the steam properties (TEMPERATURE,ENTHALPY, etc.)
      *
-     * @return SteamProperties::Output, steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, steam properties
      */
-	Output calculate();
+     SteamSystemModelerTool::SteamPropertiesOutput calculate();
 
 private:
     /**
      * Calculates the steam properties using temperature
      * @param pressure double, pressure in MPa
      * @param temperature double, temperature in Kelvins
-     * @return SteamProperties::Output, steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, steam properties
      */
-	SteamProperties::Output waterPropertiesPressureTemperature(double pressure, double temperature);
+	SteamSystemModelerTool::SteamPropertiesOutput waterPropertiesPressureTemperature(double pressure, double temperature);
 
     /**
      * Calculates the steam properties using specific enthalpy
      * @param pressure double, pressure in MPa
      * @param enthalpy double, specific enthalpy in kJ/kg
-     * @return SteamProperties::Output, steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, steam properties
      */
-	SteamProperties::Output waterPropertiesPressureEnthalpy(double pressure, double enthalpy);
+	SteamSystemModelerTool::SteamPropertiesOutput waterPropertiesPressureEnthalpy(double pressure, double enthalpy);
 
     /**
      * Calculates the steam properties using specific entropy
      * @param pressure double, pressure in MPa
      * @param entropy double, specific entropy in kJ/kg/K
-     * @return SteamProperties::Output, steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, steam properties
      */
-	SteamProperties::Output waterPropertiesPressureEntropy(double pressure, double entropy);
+	SteamSystemModelerTool::SteamPropertiesOutput waterPropertiesPressureEntropy(double pressure, double entropy);
 
     /**
      * Calculates the steam properties using specific quality
      * @param pressure double, pressure in MPa
      * @param quality double, specific quality - unitless
-     * @return SteamProperties::Output, steam properties
+     * @return SteamSystemModelerTool::SteamPropertiesOutput, steam properties
      */
-	SteamProperties::Output waterPropertiesPressureQuality(double pressure, double quality);
+	SteamSystemModelerTool::SteamPropertiesOutput waterPropertiesPressureQuality(double pressure, double quality);
 
 //	enum class Region {
 //		LIQUIDREGION1,

--- a/include/ssmt/SteamProperties.h
+++ b/include/ssmt/SteamProperties.h
@@ -6,6 +6,34 @@
 
 class SteamProperties {
 public:
+	/**
+	 * SteamProperties::Output contains the properties of steam
+	 * @param temperature in Kelvin
+	 * @param pressure in MPa
+	 * @param quality - unitless
+	 * @param specificVolume in m³/kg
+	 * @param density in kg/m³
+	 * @param specificEnthalpy in kJ/kg
+	 * @param specificEntropy in kJ/kg/K
+	 * @param internalEnergy - optional parameter - in MJ
+	 */
+	struct Output {
+		Output(const double temperature, const double pressure, const double quality,
+		       const double specificVolume, const double density, const double specificEnthalpy,
+		       const double specificEntropy, const double internalEnergy = 0):
+				temperature(temperature), pressure(pressure), quality(quality), specificVolume(specificVolume),
+				density(density), specificEnthalpy(specificEnthalpy), specificEntropy(specificEntropy),
+				internalEnergy(internalEnergy)
+		{}
+
+		Output():
+				temperature(0), pressure(0), quality(0), specificVolume(0), density(0),
+				specificEnthalpy(0), specificEntropy(0), internalEnergy(0)
+		{}
+
+		double temperature, pressure, quality, specificVolume, density, specificEnthalpy, specificEntropy, internalEnergy;
+	};
+
     ///enum class for ThermodynamicQuantity
 	enum class ThermodynamicQuantity {
 		TEMPERATURE,
@@ -31,42 +59,42 @@ public:
      * @param pressure double, pressure in MPa
      * @param quantityValue ThermodynamicQuantity, the type of value that will be used to calculate the steam properties (TEMPERATURE,ENTHALPY, etc.)
      *
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	std::unordered_map <std::string, double> calculate();
+	Output calculate();
 
 private:
     /**
      * Calculates the steam properties using temperature
      * @param pressure double, pressure in MPa
      * @param temperature double, temperature in Kelvins
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	std::unordered_map <std::string, double> waterPropertiesPressureTemperature(double pressure, double temperature);
+	SteamProperties::Output waterPropertiesPressureTemperature(double pressure, double temperature);
 
     /**
      * Calculates the steam properties using specific enthalpy
      * @param pressure double, pressure in MPa
      * @param enthalpy double, specific enthalpy in kJ/kg
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	std::unordered_map <std::string, double> waterPropertiesPressureEnthalpy(double pressure, double enthalpy);
+	SteamProperties::Output waterPropertiesPressureEnthalpy(double pressure, double enthalpy);
 
     /**
      * Calculates the steam properties using specific entropy
      * @param pressure double, pressure in MPa
      * @param entropy double, specific entropy in kJ/kg/K
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	std::unordered_map <std::string, double> waterPropertiesPressureEntropy(double pressure, double entropy);
+	SteamProperties::Output waterPropertiesPressureEntropy(double pressure, double entropy);
 
     /**
      * Calculates the steam properties using specific quality
      * @param pressure double, pressure in MPa
      * @param quality double, specific quality - unitless
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	std::unordered_map <std::string, double> waterPropertiesPressureQuality(double pressure, double quality);
+	SteamProperties::Output waterPropertiesPressureQuality(double pressure, double quality);
 
 //	enum class Region {
 //		LIQUIDREGION1,

--- a/include/ssmt/SteamSystemModelerTool.h
+++ b/include/ssmt/SteamSystemModelerTool.h
@@ -40,15 +40,44 @@ public:
                 internalEnergy(internalEnergy)
         {}
 
-        SteamPropertiesOutput():
-                temperature(0), pressure(0), quality(0), specificVolume(0), density(0),
-                specificEnthalpy(0), specificEntropy(0), internalEnergy(0)
-        {}
+        SteamPropertiesOutput() = default;
 
-        double temperature, pressure, quality, specificVolume, density, specificEnthalpy, specificEntropy, internalEnergy;
+        double temperature = 0, pressure = 0, quality = 0, specificVolume = 0, density = 0;
+        double specificEnthalpy = 0, specificEntropy = 0, internalEnergy = 0;
     };
 
+    /**
+    * SteamPropertiesOutput contains the properties of steam
+     * @param pressure, pressure in MPa
+     * @param temperature,  temperature in Kelvin
+     * @param gasSpecificEnthalpy, enthalpy in kJ/kg
+     * @param gasSpecificEntropy,  entropy in kJ/kg/K
+     * @param gasSpecificVolume,  volume in m³/kg
+     * @param liquidSpecificEnthalpy,  enthalpy in kJ/kg
+     * @param liquidSpecificEntropy,  entropy in kJ/kg/K
+     * @param liquidSpecificVolume,  volume in m³/kg
+     * @param evaporationSpecificEnthalpy,  enthalpy in kJ/kg
+     * @param evaporationSpecificEntropy,  entropy in kJ/kg/K
+     * @param evaporationSpecificVolume,  volume in m³/kg
+    */
+    struct SaturatedPropertiesOutput {
+        SaturatedPropertiesOutput(const double temperature, const double pressure,
+                                  const double gasSpecificVolume, const double gasSpecificEnthalpy, const double gasSpecificEntropy,
+                                  const double liquidSpecificVolume, const double liquidSpecificEnthalpy, const double liquidSpecificEntropy,
+                                  const double evaporationSpecificVolume, const double evaporationSpecificEnthalpy, const double evaporationSpecificEntropy):
+                temperature(temperature), pressure(pressure),
+                gasSpecificVolume(gasSpecificVolume), gasSpecificEnthalpy(gasSpecificEnthalpy), gasSpecificEntropy(gasSpecificEntropy),
+                liquidSpecificVolume(liquidSpecificVolume), liquidSpecificEnthalpy(liquidSpecificEnthalpy), liquidSpecificEntropy(liquidSpecificEntropy),
+                evaporationSpecificVolume(evaporationSpecificVolume), evaporationSpecificEnthalpy(evaporationSpecificEnthalpy), evaporationSpecificEntropy(evaporationSpecificEntropy)
+        {}
 
+        SaturatedPropertiesOutput() = default;
+
+        double temperature = 0, pressure = 0;
+        double gasSpecificVolume = 0, gasSpecificEnthalpy = 0, gasSpecificEntropy = 0;
+        double liquidSpecificVolume = 0, liquidSpecificEnthalpy = 0, liquidSpecificEntropy = 0;
+        double evaporationSpecificVolume = 0, evaporationSpecificEnthalpy = 0, evaporationSpecificEntropy = 0;
+    };
 
     struct FluidProperties: public SteamPropertiesOutput {
         FluidProperties(const double massFlow, const double energyFlow, const double temperature, const double pressure,
@@ -59,15 +88,15 @@ public:
                 massFlow(massFlow), energyFlow(energyFlow)
         {}
 
-        FluidProperties(): SteamPropertiesOutput(), massFlow(0), energyFlow(0) {}
-
         FluidProperties(const double massFlow, const double energyFlow, SteamPropertiesOutput const & sp):
                 SteamPropertiesOutput(sp.temperature, sp.pressure, sp.quality, sp.specificVolume, sp.density,
                                         sp.specificEnthalpy, sp.specificEntropy, sp.internalEnergy),
                 massFlow(massFlow), energyFlow(energyFlow)
         {}
 
-        double massFlow, energyFlow;
+        FluidProperties() = default;
+
+        double massFlow = 0, energyFlow = 0;
     };
 
     enum class Key{

--- a/include/ssmt/SteamSystemModelerTool.h
+++ b/include/ssmt/SteamSystemModelerTool.h
@@ -3,8 +3,6 @@
 
 #include <cmath>
 #include <string>
-#include <unordered_map>
-#include "SteamProperties.h"
 
 class Point {
 public:
@@ -22,19 +20,49 @@ private:
 
 class SteamSystemModelerTool {
 public:
-    struct FluidProperties: public SteamProperties::Output {
+    /**
+    * SteamPropertiesOutput contains the properties of steam
+    * @param temperature in Kelvin
+    * @param pressure in MPa
+    * @param quality - unitless
+    * @param specificVolume in m³/kg
+    * @param density in kg/m³
+    * @param specificEnthalpy in kJ/kg
+    * @param specificEntropy in kJ/kg/K
+    * @param internalEnergy - optional parameter - in MJ
+    */
+    struct SteamPropertiesOutput {
+        SteamPropertiesOutput(const double temperature, const double pressure, const double quality,
+                              const double specificVolume, const double density, const double specificEnthalpy,
+                              const double specificEntropy, const double internalEnergy = 0):
+                temperature(temperature), pressure(pressure), quality(quality), specificVolume(specificVolume),
+                density(density), specificEnthalpy(specificEnthalpy), specificEntropy(specificEntropy),
+                internalEnergy(internalEnergy)
+        {}
+
+        SteamPropertiesOutput():
+                temperature(0), pressure(0), quality(0), specificVolume(0), density(0),
+                specificEnthalpy(0), specificEntropy(0), internalEnergy(0)
+        {}
+
+        double temperature, pressure, quality, specificVolume, density, specificEnthalpy, specificEntropy, internalEnergy;
+    };
+
+
+
+    struct FluidProperties: public SteamPropertiesOutput {
         FluidProperties(const double massFlow, const double energyFlow, const double temperature, const double pressure,
                         const double quality, const double specificVolume, const double density, const double specificEnthalpy,
                         const double specificEntropy, const double internalEnergy = 0):
-                SteamProperties::Output(temperature, pressure, quality, specificVolume, density, specificEnthalpy,
+                SteamPropertiesOutput(temperature, pressure, quality, specificVolume, density, specificEnthalpy,
                                         specificEntropy, internalEnergy),
                 massFlow(massFlow), energyFlow(energyFlow)
         {}
 
-        FluidProperties(): SteamProperties::Output(), massFlow(0), energyFlow(0) {}
+        FluidProperties(): SteamPropertiesOutput(), massFlow(0), energyFlow(0) {}
 
-        FluidProperties(const double massFlow, const double energyFlow, SteamProperties::Output const & sp):
-                SteamProperties::Output(sp.temperature, sp.pressure, sp.quality, sp.specificVolume, sp.density,
+        FluidProperties(const double massFlow, const double energyFlow, SteamPropertiesOutput const & sp):
+                SteamPropertiesOutput(sp.temperature, sp.pressure, sp.quality, sp.specificVolume, sp.density,
                                         sp.specificEnthalpy, sp.specificEntropy, sp.internalEnergy),
                 massFlow(massFlow), energyFlow(energyFlow)
         {}
@@ -70,9 +98,9 @@ private:
      * @param temperature double, temperature in Kelvin
      * @param pressure double, pressure in MPa
      *
-     * @return SteamProperties::Output, steam properties
+     * @return SteamPropertiesOutput, steam properties
      */
-	static SteamProperties::Output region1(double temperature, double pressure);
+	static SteamPropertiesOutput region1(double temperature, double pressure);
 
     /**
      * Calculates the steam properties using region 2 equations
@@ -82,7 +110,7 @@ private:
      *
      * @return SteamProperties::Output, steam properties
      */
-	static SteamProperties::Output region2(double temperature, double pressure);
+	static SteamPropertiesOutput region2(double temperature, double pressure);
 
     /**
      * Calculates the steam properties using region 3 equations
@@ -92,9 +120,9 @@ private:
      *
      * @return SteamProperties::Output, steam properties
      */
-	static SteamProperties::Output region3(double temperature, double pressure);
+	static SteamPropertiesOutput region3(double temperature, double pressure);
 
-	static SteamProperties::Output region3Density(double density, double temperature);
+	static SteamPropertiesOutput region3Density(double density, double temperature);
 
     /**
      * Calculates the steam properties using region 4 equations (saturated properties)

--- a/include/ssmt/SteamSystemModelerTool.h
+++ b/include/ssmt/SteamSystemModelerTool.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <string>
 #include <unordered_map>
+#include "SteamProperties.h"
 
 class Point {
 public:
@@ -21,6 +22,26 @@ private:
 
 class SteamSystemModelerTool {
 public:
+    struct FluidProperties: public SteamProperties::Output {
+        FluidProperties(const double massFlow, const double energyFlow, const double temperature, const double pressure,
+                        const double quality, const double specificVolume, const double density, const double specificEnthalpy,
+                        const double specificEntropy, const double internalEnergy = 0):
+                SteamProperties::Output(temperature, pressure, quality, specificVolume, density, specificEnthalpy,
+                                        specificEntropy, internalEnergy),
+                massFlow(massFlow), energyFlow(energyFlow)
+        {}
+
+        FluidProperties(): SteamProperties::Output(), massFlow(0), energyFlow(0) {}
+
+        FluidProperties(const double massFlow, const double energyFlow, SteamProperties::Output const & sp):
+                SteamProperties::Output(sp.temperature, sp.pressure, sp.quality, sp.specificVolume, sp.density,
+                                        sp.specificEnthalpy, sp.specificEntropy, sp.internalEnergy),
+                massFlow(massFlow), energyFlow(energyFlow)
+        {}
+
+        double massFlow, energyFlow;
+    };
+
     enum class Key{
         ENTHALPY,
         ENTROPY
@@ -49,9 +70,9 @@ private:
      * @param temperature double, temperature in Kelvin
      * @param pressure double, pressure in MPa
      *
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	static std::unordered_map <std::string, double> region1(double temperature, double pressure);
+	static SteamProperties::Output region1(double temperature, double pressure);
 
     /**
      * Calculates the steam properties using region 2 equations
@@ -59,9 +80,9 @@ private:
      * @param temperature double, temperature in Kelvin
      * @param pressure double, pressure in MPa
      *
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	static std::unordered_map <std::string, double> region2(double temperature, double pressure);
+	static SteamProperties::Output region2(double temperature, double pressure);
 
     /**
      * Calculates the steam properties using region 3 equations
@@ -69,11 +90,11 @@ private:
      * @param temperature double, temperature in Kelvin
      * @param pressure double, pressure in MPa
      *
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
-	static std::unordered_map <std::string, double> region3(double temperature, double pressure);
+	static SteamProperties::Output region3(double temperature, double pressure);
 
-	static std::unordered_map <std::string, double> region3Density(double density, double temperature);
+	static SteamProperties::Output region3Density(double density, double temperature);
 
     /**
      * Calculates the steam properties using region 4 equations (saturated properties)
@@ -81,7 +102,7 @@ private:
      * @param temperature double, temperature in Kelvin
      * @param pressure double, pressure in MPa
      *
-     * @return unordered_map <string, double>, steam properties
+     * @return SteamProperties::Output, steam properties
      */
 	static double region4(double temperature);
 
@@ -332,13 +353,6 @@ private:
     static inline double boundaryByPressureRegion3to2(const double p) {
         return 0.57254459862746E+03 + std::pow((p - 0.13918839778870E+02) / 0.10192970039326E-02, 0.5);
     }
-
-//	static int regionSelect(const double pressure, const double temperature);
-//	static std::unordered_map <std::string, double> region1(const double pressure, const double temperature);
-//	static std::unordered_map <std::string, double> region2(const double pressure, const double temperature);
-//	static std::unordered_map <std::string, double> region3(const double pressure, const double temperature);
-//	static std::unordered_map <std::string, double> region3Density(const double density, const double temperature);
-//	static double region4(const double temperature);
 
 	friend class SteamProperties;
     friend class SaturatedProperties;

--- a/include/ssmt/Turbine.h
+++ b/include/ssmt/Turbine.h
@@ -35,8 +35,8 @@ public:
 	double getInletQuantityValue() const { return inletQuantityValue; }
 	double getOutletQuantityValue() const { return outletQuantityValue; }
 	TurbineProperty getTurbineProperty() const { return turbineProperty; }
-	std::unordered_map<std::string, double> const & getInletProperties() const { return inletProperties; }
-	std::unordered_map<std::string, double> const & getOutletProperties() const { return outletProperties; }
+	SteamSystemModelerTool::SteamPropertiesOutput const & getInletProperties() const { return inletProperties; }
+	SteamSystemModelerTool::SteamPropertiesOutput const & getOutletProperties() const { return outletProperties; }
 	double getInletEnergyFlow() const { return inletEnergyFlow; }
 	double getOutletEnergyFlow() const { return outletEnergyFlow; }
 	double getPowerOut() const { return powerOut; }
@@ -67,7 +67,7 @@ private:
 	double inletQuantityValue, outletQuantityValue = 0;
 	TurbineProperty turbineProperty;
 
-	std::unordered_map<std::string, double> inletProperties, outletProperties;
+	SteamSystemModelerTool::SteamPropertiesOutput inletProperties, outletProperties;
 
 	double inletEnergyFlow, outletEnergyFlow = 0, energyOut, powerOut, massFlow;
 };

--- a/src/ssmt/Boiler.cpp
+++ b/src/ssmt/Boiler.cpp
@@ -20,23 +20,37 @@ Boiler::Boiler(const double deaeratorPressure, const double combustionEfficiency
 }
 
 void Boiler::calculateProperties() {
-	steamProperties = SteamProperties(steamPressure, quantityType, quantityValue).calculate();
-	steamProperties["steamEnergyFlow"] = steamProperties.at("specificEnthalpy") * steamMassFlow / 1000;
-	steamProperties["steamMassFlow"] = steamMassFlow;
-	steamProperties["quality"] = 1; // TODO tell UI guys that there needs to be warning
+	auto sp = SteamProperties(steamPressure, quantityType, quantityValue).calculate();
+	steamProperties = {steamMassFlow, sp.specificEnthalpy * steamMassFlow / 1000, sp};
+	steamProperties.quality = 1; // TODO question tell UI guys that there needs to be a warning
 
-	feedwaterProperties = SteamProperties(deaeratorPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
-	feedwaterProperties["feedwaterMassFlow"] = steamMassFlow / (1 - blowdownRate / 100);
-	feedwaterProperties["feedwaterEnergyFlow"] = feedwaterProperties.at("specificEnthalpy")
-	                                             * feedwaterProperties.at("feedwaterMassFlow") / 1000;
+//	steamProperties["steamEnergyFlow"] = steamProperties.at("specificEnthalpy") * steamMassFlow / 1000;
+//	steamProperties["steamMassFlow"] = steamMassFlow;
+//	steamProperties["quality"] = 1; // TODO tell UI guys that there needs to be warning
 
-	blowdownProperties = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
-	blowdownProperties["blowdownMassFlow"] = feedwaterProperties.at("feedwaterMassFlow") * (blowdownRate / 100);
-	blowdownProperties["blowdownEnergyFlow"] = blowdownProperties.at("specificEnthalpy")
-	                                           * blowdownProperties.at("blowdownMassFlow") / 1000;
+	sp = SteamProperties(deaeratorPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
+	feedwaterProperties = {steamMassFlow / (1 - blowdownRate / 100),
+	                       sp.specificEnthalpy * (steamMassFlow / (1 - blowdownRate / 100)) / 1000, sp};
 
-	boilerEnergy = steamProperties.at("steamEnergyFlow") + blowdownProperties.at("blowdownEnergyFlow")
-	               - feedwaterProperties.at("feedwaterEnergyFlow");
+//	feedwaterProperties = SteamProperties(deaeratorPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
+//	feedwaterProperties["feedwaterMassFlow"] = steamMassFlow / (1 - blowdownRate / 100);
+//	feedwaterProperties["feedwaterEnergyFlow"] = feedwaterProperties.at("specificEnthalpy")
+//	                                             * feedwaterProperties.at("feedwaterMassFlow") / 1000;
+
+	sp = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
+	blowdownProperties = {feedwaterProperties.massFlow * (blowdownRate / 100),
+	                      blowdownProperties.specificEnthalpy * blowdownProperties.massFlow / 1000, sp};
+
+//	blowdownProperties = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
+//	blowdownProperties["blowdownMassFlow"] = feedwaterProperties.at("feedwaterMassFlow") * (blowdownRate / 100);
+//	blowdownProperties["blowdownEnergyFlow"] = blowdownProperties.at("specificEnthalpy")
+//	                                           * blowdownProperties.at("blowdownMassFlow") / 1000;
+
+
+	boilerEnergy = steamProperties.energyFlow + blowdownProperties.energyFlow - feedwaterProperties.energyFlow;
+
+//	boilerEnergy = steamProperties.at("steamEnergyFlow") + blowdownProperties.at("blowdownEnergyFlow")
+//	               - feedwaterProperties.at("feedwaterEnergyFlow");
 	fuelEnergy = boilerEnergy / (combustionEfficiency / 100);
 }
 

--- a/src/ssmt/Boiler.cpp
+++ b/src/ssmt/Boiler.cpp
@@ -38,8 +38,8 @@ void Boiler::calculateProperties() {
 //	                                             * feedwaterProperties.at("feedwaterMassFlow") / 1000;
 
 	sp = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
-	blowdownProperties = {feedwaterProperties.massFlow * (blowdownRate / 100),
-	                      blowdownProperties.specificEnthalpy * blowdownProperties.massFlow / 1000, sp};
+	double const blowdownMassFlow = feedwaterProperties.massFlow * (blowdownRate / 100);
+	blowdownProperties = {blowdownMassFlow, sp.specificEnthalpy * blowdownMassFlow / 1000, sp};
 
 //	blowdownProperties = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
 //	blowdownProperties["blowdownMassFlow"] = feedwaterProperties.at("feedwaterMassFlow") * (blowdownRate / 100);

--- a/src/ssmt/Boiler.cpp
+++ b/src/ssmt/Boiler.cpp
@@ -24,33 +24,15 @@ void Boiler::calculateProperties() {
 	steamProperties = {steamMassFlow, sp.specificEnthalpy * steamMassFlow / 1000, sp};
 	steamProperties.quality = 1; // TODO question tell UI guys that there needs to be a warning
 
-//	steamProperties["steamEnergyFlow"] = steamProperties.at("specificEnthalpy") * steamMassFlow / 1000;
-//	steamProperties["steamMassFlow"] = steamMassFlow;
-//	steamProperties["quality"] = 1; // TODO tell UI guys that there needs to be warning
-
 	sp = SteamProperties(deaeratorPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
 	feedwaterProperties = {steamMassFlow / (1 - blowdownRate / 100),
 	                       sp.specificEnthalpy * (steamMassFlow / (1 - blowdownRate / 100)) / 1000, sp};
-
-//	feedwaterProperties = SteamProperties(deaeratorPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
-//	feedwaterProperties["feedwaterMassFlow"] = steamMassFlow / (1 - blowdownRate / 100);
-//	feedwaterProperties["feedwaterEnergyFlow"] = feedwaterProperties.at("specificEnthalpy")
-//	                                             * feedwaterProperties.at("feedwaterMassFlow") / 1000;
 
 	sp = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
 	double const blowdownMassFlow = feedwaterProperties.massFlow * (blowdownRate / 100);
 	blowdownProperties = {blowdownMassFlow, sp.specificEnthalpy * blowdownMassFlow / 1000, sp};
 
-//	blowdownProperties = SteamProperties(steamPressure, SteamProperties::ThermodynamicQuantity::QUALITY, 0).calculate();
-//	blowdownProperties["blowdownMassFlow"] = feedwaterProperties.at("feedwaterMassFlow") * (blowdownRate / 100);
-//	blowdownProperties["blowdownEnergyFlow"] = blowdownProperties.at("specificEnthalpy")
-//	                                           * blowdownProperties.at("blowdownMassFlow") / 1000;
-
-
 	boilerEnergy = steamProperties.energyFlow + blowdownProperties.energyFlow - feedwaterProperties.energyFlow;
-
-//	boilerEnergy = steamProperties.at("steamEnergyFlow") + blowdownProperties.at("blowdownEnergyFlow")
-//	               - feedwaterProperties.at("feedwaterEnergyFlow");
 	fuelEnergy = boilerEnergy / (combustionEfficiency / 100);
 }
 

--- a/src/ssmt/Deaerator.cpp
+++ b/src/ssmt/Deaerator.cpp
@@ -23,44 +23,19 @@ Deaerator::Deaerator(const double deaeratorPressure, const double ventRate, cons
 
 void Deaerator::calculateProperties() {
     auto const sp = SaturatedProperties(deaeratorPressure, SaturatedTemperature(deaeratorPressure).calculate()).calculate();
-	SteamSystemModelerTool::SteamPropertiesOutput steamProps = {sp.at("temperature"), sp.at("pressure"), 0, 0, 0, sp.at("liquidSpecificEnthalpy"),
-																sp.at("liquidSpecificEntropy")};
+	SteamSystemModelerTool::SteamPropertiesOutput steamProps = {sp.temperature, sp.pressure, 0, 0, 0, sp.liquidSpecificEnthalpy,
+																sp.liquidSpecificEntropy};
 	feedwaterProperties = {feedwaterMassFlow, steamProps.specificEnthalpy * feedwaterMassFlow / 1000, steamProps};
-//    feedwaterProperties = {
-//            {"temperature", sp.at("temperature")},
-//            {"pressure", sp.at("pressure")},
-//            {"specificEnthalpy", sp.at("liquidSpecificEnthalpy")},
-//            {"specificEntropy", sp.at("liquidSpecificEntropy")},
-//            {"quality", 0},
-//            {"massFlow", feedwaterMassFlow},
-//            {"energyFlow", sp.at("liquidSpecificEnthalpy") * feedwaterMassFlow / 1000}
-//    };
 
-	steamProps = {sp.at("temperature"), sp.at("pressure"), 1, 0, 0, sp.at("gasSpecificEnthalpy"),
-				  sp.at("gasSpecificEntropy")};
+	steamProps = {sp.temperature, sp.pressure, 1, 0, 0, sp.gasSpecificEnthalpy,
+				  sp.gasSpecificEntropy};
 	auto const ventedSteamMassFlow = (ventRate / 100) * feedwaterMassFlow;
 	ventedSteamProperties = {
 			ventedSteamMassFlow, steamProps.specificEnthalpy * ventedSteamMassFlow / 1000, steamProps
 	};
 
-//    auto const ventedSteamMassFlow = (ventRate / 100) * feedwaterMassFlow;
-//    ventedSteamProperties = {
-//            {"temperature", sp.at("temperature")},
-//            {"pressure", sp.at("pressure")},
-//            {"specificEnthalpy", sp.at("gasSpecificEnthalpy")},
-//            {"specificEntropy", sp.at("gasSpecificEntropy")},
-//            {"quality", 1},
-//            {"massFlow", ventedSteamMassFlow},
-//            {"energyFlow", sp.at("gasSpecificEnthalpy") * ventedSteamMassFlow / 1000}
-//    };
-
-//    inletWaterProperties = SteamProperties(waterPressure, waterQuantityType, waterQuantityValue).calculate();
-//    inletSteamProperties = SteamProperties(steamPressure, steamQuantityType, steamQuantityValue).calculate();
-
 	auto inletWaterProps = SteamProperties(waterPressure, waterQuantityType, waterQuantityValue).calculate();
 	auto inletSteamProps = SteamProperties(steamPressure, steamQuantityType, steamQuantityValue).calculate();
-
-
 
     auto const totalDAMassFlow = ventedSteamMassFlow + feedwaterMassFlow;
     auto const totalOutletEnergyFlow = (feedwaterProperties.specificEnthalpy * feedwaterMassFlow
@@ -81,12 +56,6 @@ void Deaerator::calculateProperties() {
 	inletSteamProperties = {
 			inletSteamMassFlow, inletSteamEnergyFlow, inletSteamProps
 	};
-
-//    inletWaterProperties["massFlow"] = inletWaterMassFlow;
-//    inletWaterProperties["energyFlow"] = inletWaterEnergyFlow;
-
-//    inletSteamProperties["massFlow"] = inletSteamMassFlow;
-//    inletSteamProperties["energyFlow"] = inletSteamEnergyFlow;
 }
 
 double Deaerator::getDeaeratorPressure() const { return deaeratorPressure; }

--- a/src/ssmt/Deaerator.cpp
+++ b/src/ssmt/Deaerator.cpp
@@ -65,14 +65,14 @@ void Deaerator::calculateProperties() {
     auto const totalDAMassFlow = ventedSteamMassFlow + feedwaterMassFlow;
     auto const totalOutletEnergyFlow = (feedwaterProperties.specificEnthalpy * feedwaterMassFlow
                                         + ventedSteamProperties.specificEnthalpy * ventedSteamMassFlow) / 1000;
-    auto const minEnergyFlow = inletWaterProperties.specificEnthalpy * totalDAMassFlow / 1000;
+    auto const minEnergyFlow = inletWaterProps.specificEnthalpy * totalDAMassFlow / 1000;
     auto const neededEnergyFlow = totalOutletEnergyFlow - minEnergyFlow;
-    auto const inletSteamMassFlow = 1000 * neededEnergyFlow / (inletSteamProperties.specificEnthalpy
-                                                               - inletWaterProperties.specificEnthalpy);
+    auto const inletSteamMassFlow = 1000 * neededEnergyFlow / (inletSteamProps.specificEnthalpy
+                                                               - inletWaterProps.specificEnthalpy);
 
     auto const inletWaterMassFlow = totalDAMassFlow - inletSteamMassFlow;
-    auto const inletSteamEnergyFlow = inletSteamProperties.specificEnthalpy * inletSteamMassFlow / 1000;
-    auto const inletWaterEnergyFlow = inletWaterProperties.specificEnthalpy * inletWaterMassFlow / 1000;
+    auto const inletSteamEnergyFlow = inletSteamProps.specificEnthalpy * inletSteamMassFlow / 1000;
+    auto const inletWaterEnergyFlow = inletWaterProps.specificEnthalpy * inletWaterMassFlow / 1000;
 
 	inletWaterProperties = {
 			inletWaterMassFlow, inletWaterEnergyFlow, inletWaterProps

--- a/src/ssmt/FlashTank.cpp
+++ b/src/ssmt/FlashTank.cpp
@@ -31,9 +31,10 @@ void FlashTank::calculateProperties() {
     auto saturatedProperties = SaturatedProperties(tankPressure, SaturatedTemperature(tankPressure).calculate()).calculate();
 	double const liquidMassFlow = inletWaterMassFlow * (inletWaterProperties.specificEnthalpy - saturatedProperties.at("gasSpecificEnthalpy"))
 						  / (saturatedProperties.at("liquidSpecificEnthalpy") - saturatedProperties.at("gasSpecificEnthalpy"));
+	// TODO question density is 0 below bc saturated properties doesn't return density, same with both sp objects here
     sp = {
 			saturatedProperties.at("temperature"), saturatedProperties.at("pressure"), 0,
-			saturatedProperties.at("specificVolume"), saturatedProperties.at("density"),
+			saturatedProperties.at("liquidSpecificVolume"), 0,
 			saturatedProperties.at("liquidSpecificEnthalpy"), saturatedProperties.at("liquidSpecificEntropy")
 	};
 	outletLiquidSaturatedProperties = {
@@ -44,7 +45,7 @@ void FlashTank::calculateProperties() {
 
 	sp = {
 			saturatedProperties.at("temperature"), saturatedProperties.at("pressure"), 1,
-			saturatedProperties.at("specificVolume"), saturatedProperties.at("density"),
+			saturatedProperties.at("gasSpecificVolume"), 0,
 			saturatedProperties.at("gasSpecificEnthalpy"), saturatedProperties.at("gasSpecificEntropy")
 	};
 	double const gasMassFlow = inletWaterMassFlow - outletLiquidSaturatedProperties.massFlow;

--- a/src/ssmt/FlashTank.cpp
+++ b/src/ssmt/FlashTank.cpp
@@ -18,6 +18,12 @@ FlashTank::FlashTank(const double inletWaterPressure, const SteamProperties::The
 }
 
 void FlashTank::calculateProperties() {
+	// here do this
+	auto sp =  SteamProperties(inletWaterPressure, quantityType, quantityValue).calculate();
+	inletWaterProperties["massFlow"] = inletWaterMassFlow;
+	inletWaterProperties["energyFlow"] = inletWaterMassFlow * inletWaterProperties.at("specificEnthalpy") / 1000;
+
+
     inletWaterProperties = SteamProperties(inletWaterPressure, quantityType, quantityValue).calculate();
 	inletWaterProperties["massFlow"] = inletWaterMassFlow;
 	inletWaterProperties["energyFlow"] = inletWaterMassFlow * inletWaterProperties.at("specificEnthalpy") / 1000;

--- a/src/ssmt/FlashTank.cpp
+++ b/src/ssmt/FlashTank.cpp
@@ -21,52 +21,28 @@ void FlashTank::calculateProperties() {
 	auto sp =  SteamProperties(inletWaterPressure, quantityType, quantityValue).calculate();
     inletWaterProperties = {inletWaterMassFlow, inletWaterMassFlow * sp.specificEnthalpy / 1000, sp};
 
-//    inletWaterProperties = SteamProperties(inletWaterPressure, quantityType, quantityValue).calculate();
-//	inletWaterProperties["massFlow"] = inletWaterMassFlow;
-//	inletWaterProperties["energyFlow"] = inletWaterMassFlow * inletWaterProperties.at("specificEnthalpy") / 1000;
-
-//	if (quantityType == SteamProperties::ThermodynamicQuantity::QUALITY) inletWaterProperties["quality"] = quantityValue;
-//	else inletWaterProperties["quality"] = 0;
-
     auto saturatedProperties = SaturatedProperties(tankPressure, SaturatedTemperature(tankPressure).calculate()).calculate();
-	double const liquidMassFlow = inletWaterMassFlow * (inletWaterProperties.specificEnthalpy - saturatedProperties.at("gasSpecificEnthalpy"))
-						  / (saturatedProperties.at("liquidSpecificEnthalpy") - saturatedProperties.at("gasSpecificEnthalpy"));
+	double const liquidMassFlow = inletWaterMassFlow * (inletWaterProperties.specificEnthalpy - saturatedProperties.gasSpecificEnthalpy)
+						  / (saturatedProperties.liquidSpecificEnthalpy - saturatedProperties.gasSpecificEnthalpy);
 	// TODO question density is 0 below bc saturated properties doesn't return density, same with both sp objects here
     sp = {
-			saturatedProperties.at("temperature"), saturatedProperties.at("pressure"), 0,
-			saturatedProperties.at("liquidSpecificVolume"), 0,
-			saturatedProperties.at("liquidSpecificEnthalpy"), saturatedProperties.at("liquidSpecificEntropy")
+			saturatedProperties.temperature, saturatedProperties.pressure, 0,
+			saturatedProperties.liquidSpecificVolume, 0,
+			saturatedProperties.liquidSpecificEnthalpy, saturatedProperties.liquidSpecificEntropy
 	};
 	outletLiquidSaturatedProperties = {
             liquidMassFlow,
-			liquidMassFlow * saturatedProperties.at("liquidSpecificEnthalpy") / 1000,
+			liquidMassFlow * saturatedProperties.liquidSpecificEnthalpy / 1000,
             sp
 	};
 
 	sp = {
-			saturatedProperties.at("temperature"), saturatedProperties.at("pressure"), 1,
-			saturatedProperties.at("gasSpecificVolume"), 0,
-			saturatedProperties.at("gasSpecificEnthalpy"), saturatedProperties.at("gasSpecificEntropy")
+			saturatedProperties.temperature, saturatedProperties.pressure, 1,
+			saturatedProperties.gasSpecificVolume, 0,
+			saturatedProperties.gasSpecificEnthalpy, saturatedProperties.gasSpecificEntropy
 	};
 	double const gasMassFlow = inletWaterMassFlow - outletLiquidSaturatedProperties.massFlow;
 	outletGasSaturatedProperties = {gasMassFlow, gasMassFlow * sp.specificEnthalpy / 1000, sp};
-
-//	outletSaturatedProperties = SaturatedProperties(tankPressure, SaturatedTemperature(tankPressure).calculate()).calculate();
-//    outletSaturatedProperties["liquidMassFlow"] = inletWaterMassFlow
-//                                                  * (inletWaterProperties.at("specificEnthalpy")
-//                                                     - outletSaturatedProperties.at("gasSpecificEnthalpy"))
-//                                                  / (outletSaturatedProperties.at("liquidSpecificEnthalpy")
-//                                                     - outletSaturatedProperties.at("gasSpecificEnthalpy"));
-
-//    outletSaturatedProperties["gasMassFlow"] = inletWaterMassFlow - outletSaturatedProperties.at("liquidMassFlow");
-//	outletSaturatedProperties["gasQuality"] = 1;
-//
-//    outletSaturatedProperties["gasEnergyFlow"] = outletSaturatedProperties.at("gasMassFlow")
-//                                                 * outletSaturatedProperties.at("gasSpecificEnthalpy") / 1000;
-
-//    outletSaturatedProperties["liquidEnergyFlow"] = outletSaturatedProperties.at("liquidMassFlow")
-//                                                    * outletSaturatedProperties.at("liquidSpecificEnthalpy") / 1000;
-//	outletSaturatedProperties["liquidQuality"] = 0;
 }
 
 double FlashTank::getInletWaterPressure() const { return inletWaterPressure; }

--- a/src/ssmt/Header.cpp
+++ b/src/ssmt/Header.cpp
@@ -40,7 +40,7 @@ void Header::setInlets(std::vector<Inlet> & inlets) {
 
 void Inlet::calculate() {
 	inletProperties = SteamProperties(pressure, quantityType, quantityValue).calculate();
-	inletEnergyFlow = inletProperties.at("specificEnthalpy") * massFlow;
+	inletEnergyFlow = inletProperties.specificEnthalpy * massFlow;
 }
 
 void Inlet::setPressure(const double pressure) {
@@ -55,7 +55,7 @@ void Inlet::setQuantityValue(const double quantityValue) {
 
 void Inlet::setMassFlow(const double massFlow) {
 	this->massFlow = massFlow;
-	inletEnergyFlow = inletProperties.at("specificEnthalpy") * massFlow;
+	inletEnergyFlow = inletProperties.specificEnthalpy * massFlow;
 }
 
 void Inlet::setQuantityType(const SteamProperties::ThermodynamicQuantity quantityType) {

--- a/src/ssmt/HeatLoss.cpp
+++ b/src/ssmt/HeatLoss.cpp
@@ -28,20 +28,6 @@ void HeatLoss::calculateProperties() {
 	                     outletEnergyFlow / inletMassFlow).calculate();
 	outletProperties = {inletMassFlow, outletEnergyFlow, sp};
 
-
-//	inletProperties = SteamProperties(inletPressure, quantityType, quantityValue).calculate();
-//	inletEnergyFlow = inletProperties.at("specificEnthalpy") * inletMassFlow / 1000;
-//	outletEnergyFlow = inletEnergyFlow * (1 - percentHeatLoss);
-
-
-
-//	outletProperties  = SteamProperties(inletPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
-//	                                    outletEnergyFlow / inletMassFlow).calculate();
-//	inletProperties["massFlow"] = inletMassFlow;
-//	inletProperties["energyFlow"] = inletEnergyFlow;
-//	outletProperties["massFlow"] = inletMassFlow;
-//	outletProperties["energyFlow"] = outletEnergyFlow;
-
 	heatLoss = inletEnergyFlow - outletEnergyFlow;
 }
 

--- a/src/ssmt/HeatLoss.cpp
+++ b/src/ssmt/HeatLoss.cpp
@@ -18,15 +18,30 @@ HeatLoss::HeatLoss(const double inletPressure, const SteamProperties::Thermodyna
 }
 
 void HeatLoss::calculateProperties() {
-	inletProperties = SteamProperties(inletPressure, quantityType, quantityValue).calculate();
-	inletEnergyFlow = inletProperties.at("specificEnthalpy") * inletMassFlow / 1000;
+	auto sp = SteamProperties(inletPressure, quantityType, quantityValue).calculate();
+	inletEnergyFlow = sp.specificEnthalpy * inletMassFlow / 1000;
 	outletEnergyFlow = inletEnergyFlow * (1 - percentHeatLoss);
-	outletProperties  = SteamProperties(inletPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
-	                                    outletEnergyFlow / inletMassFlow).calculate();
-	inletProperties["massFlow"] = inletMassFlow;
-	inletProperties["energyFlow"] = inletEnergyFlow;
-	outletProperties["massFlow"] = inletMassFlow;
-	outletProperties["energyFlow"] = outletEnergyFlow;
+
+	inletProperties = {inletMassFlow, inletEnergyFlow, sp};
+
+	sp = SteamProperties(inletPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
+	                     outletEnergyFlow / inletMassFlow).calculate();
+	outletProperties = {inletMassFlow, outletEnergyFlow, sp};
+
+
+//	inletProperties = SteamProperties(inletPressure, quantityType, quantityValue).calculate();
+//	inletEnergyFlow = inletProperties.at("specificEnthalpy") * inletMassFlow / 1000;
+//	outletEnergyFlow = inletEnergyFlow * (1 - percentHeatLoss);
+
+
+
+//	outletProperties  = SteamProperties(inletPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
+//	                                    outletEnergyFlow / inletMassFlow).calculate();
+//	inletProperties["massFlow"] = inletMassFlow;
+//	inletProperties["energyFlow"] = inletEnergyFlow;
+//	outletProperties["massFlow"] = inletMassFlow;
+//	outletProperties["energyFlow"] = outletEnergyFlow;
+
 	heatLoss = inletEnergyFlow - outletEnergyFlow;
 }
 

--- a/src/ssmt/PRV.cpp
+++ b/src/ssmt/PRV.cpp
@@ -22,8 +22,8 @@ PrvWithoutDesuperheating::PrvWithoutDesuperheating(const double inletPressure,
 void PrvWithoutDesuperheating::calculateProperties() {
 	inletProperties = SteamProperties(inletPressure, quantityType, quantityValue).calculate();
     outletProperties = SteamProperties(outletPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
-                                       inletProperties.at("specificEnthalpy")).calculate();
-    inletEnergyFlow = inletProperties.at("specificEnthalpy") * inletMassFlow / 1000;
+                                       inletProperties.specificEnthalpy).calculate();
+    inletEnergyFlow = inletProperties.specificEnthalpy * inletMassFlow / 1000;
 }
 
 PrvWithDesuperheating::PrvWithDesuperheating(const double inletPressure,
@@ -46,12 +46,11 @@ void PrvWithDesuperheating::calculateProperties() {
     outletProperties= SteamProperties(outletPressure, SteamProperties::ThermodynamicQuantity::TEMPERATURE,
                                       desuperheatingTemp).calculate();
 
-    inletEnergyFlow = inletProperties.at("specificEnthalpy") * inletMassFlow / 1000;
-    feedwaterMassFlow = inletMassFlow * (inletProperties.at("specificEnthalpy")
-                                         - outletProperties.at("specificEnthalpy"))
-                        / (outletProperties.at("specificEnthalpy") - feedwaterProperties.at("specificEnthalpy"));
+    inletEnergyFlow = inletProperties.specificEnthalpy * inletMassFlow / 1000;
+	feedwaterMassFlow = inletMassFlow * (inletProperties.specificEnthalpy - outletProperties.specificEnthalpy)
+						/ (outletProperties.specificEnthalpy - feedwaterProperties.specificEnthalpy);
 
-	feedwaterEnergyFlow = feedwaterMassFlow * feedwaterProperties.at("specificEnthalpy") / 1000;
+	feedwaterEnergyFlow = feedwaterMassFlow * feedwaterProperties.specificEnthalpy / 1000;
     outletMassFlow = inletMassFlow + feedwaterMassFlow;
-	outletEnergyFlow = outletMassFlow * outletProperties.at("specificEnthalpy") / 1000;
+	outletEnergyFlow = outletMassFlow * outletProperties.specificEnthalpy / 1000;
 }

--- a/src/ssmt/SaturatedProperties.cpp
+++ b/src/ssmt/SaturatedProperties.cpp
@@ -16,7 +16,7 @@ double SaturatedTemperature::calculate() const {
     const double C7 = -0.48232657361591E+04, C8 = 0.40511340542057E+06, C9 = -0.23855557567849E+00;
     const double C10 = 0.65017534844798E+03;
 
-    const double SS = std::pow(saturatedPressure_, 0.25);
+    const double SS = std::pow(saturatedPressure, 0.25);
     const double E = SS * SS + C3 * SS + C6;
     const double F = C1 * SS * SS + C4 * SS + C7;
     const double G = C2 * SS * SS + C5 * SS + C8;
@@ -31,7 +31,7 @@ double SaturatedPressure::calculate() const {
     const double C7 = -0.48232657361591E+04, C8 = 0.40511340542057E+06, C9 = -0.23855557567849E+00;
     const double C10 = 0.65017534844798E+03;
 
-    const double v = saturatedTemperature_ + (C9 / (saturatedTemperature_ - C10));
+    const double v = saturatedTemperature + (C9 / (saturatedTemperature - C10));
     const double vSquared = std::pow(v, 2);
 
     const double A = vSquared + (C1 * v) + C2;
@@ -41,35 +41,25 @@ double SaturatedPressure::calculate() const {
     return std::pow((2 * C) / (-B + std::sqrt(std::pow(B, 2) - 4 * A * C)), 4);
 }
 
-std::unordered_map<std::string, double> SaturatedProperties::calculate() {
-    auto const gasProperties = SteamSystemModelerTool::region2(saturatedTemperature_, saturatedPressure_);
+SteamSystemModelerTool::SaturatedPropertiesOutput SaturatedProperties::calculate() {
+    auto const gasProperties = SteamSystemModelerTool::region2(saturatedTemperature, saturatedPressure);
     SteamSystemModelerTool::SteamPropertiesOutput liquidProperties;
 
-    if ((saturatedTemperature_ >= SteamSystemModelerTool::TEMPERATURE_MIN)
-        && (saturatedTemperature_ <= SteamSystemModelerTool::TEMPERATURE_Tp)) {
-        liquidProperties = SteamSystemModelerTool::region1(saturatedTemperature_, saturatedPressure_);
+    if ((saturatedTemperature >= SteamSystemModelerTool::TEMPERATURE_MIN)
+        && (saturatedTemperature <= SteamSystemModelerTool::TEMPERATURE_Tp)) {
+        liquidProperties = SteamSystemModelerTool::region1(saturatedTemperature, saturatedPressure);
     }
 
-    if ((saturatedTemperature_ > SteamSystemModelerTool::TEMPERATURE_Tp)
-        && (saturatedTemperature_ <= SteamSystemModelerTool::TEMPERATURE_CRIT)) {
-        liquidProperties = SteamSystemModelerTool::region3(saturatedTemperature_, saturatedPressure_);
+    if ((saturatedTemperature > SteamSystemModelerTool::TEMPERATURE_Tp)
+        && (saturatedTemperature <= SteamSystemModelerTool::TEMPERATURE_CRIT)) {
+        liquidProperties = SteamSystemModelerTool::region3(saturatedTemperature, saturatedPressure);
     }
 
     const double evaporationEnthalpy = gasProperties.specificEnthalpy - liquidProperties.specificEnthalpy;
     const double evaporationEntropy = gasProperties.specificEntropy - liquidProperties.specificEntropy;
     const double evaporationVolume = gasProperties.specificVolume - liquidProperties.specificVolume;
 
-    return {
-            {"pressure", saturatedPressure_}, //pressure in MPa
-            {"temperature", saturatedTemperature_}, // temperature in Kelvin
-            {"gasSpecificEnthalpy", gasProperties.specificEnthalpy}, //enthalpy in kJ/kg
-            {"gasSpecificEntropy", gasProperties.specificEntropy}, // entropy in kJ/kg/K
-            {"gasSpecificVolume", gasProperties.specificVolume}, // volume in m³/kg
-            {"liquidSpecificEnthalpy", liquidProperties.specificEnthalpy}, // enthalpy in kJ/kg
-            {"liquidSpecificEntropy", liquidProperties.specificEntropy}, // entropy in kJ/kg/K
-            {"liquidSpecificVolume", liquidProperties.specificVolume}, // volume in m³/kg
-            {"evaporationSpecificEnthalpy", evaporationEnthalpy}, // enthalpy in kJ/kg
-            {"evaporationSpecificEntropy", evaporationEntropy}, // entropy in kJ/kg/K
-            {"evaporationSpecificVolume", evaporationVolume}, // volume in m³/kg
-    };
+	return {saturatedTemperature, saturatedPressure, gasProperties.specificVolume, gasProperties.specificEnthalpy,
+            gasProperties.specificEntropy, liquidProperties.specificVolume, liquidProperties.specificEnthalpy,
+            liquidProperties.specificEntropy, evaporationVolume, evaporationEnthalpy, evaporationEntropy};
 }

--- a/src/ssmt/SaturatedProperties.cpp
+++ b/src/ssmt/SaturatedProperties.cpp
@@ -43,7 +43,7 @@ double SaturatedPressure::calculate() const {
 
 std::unordered_map<std::string, double> SaturatedProperties::calculate() {
     auto const gasProperties = SteamSystemModelerTool::region2(saturatedTemperature_, saturatedPressure_);
-    std::unordered_map<std::string, double> liquidProperties;
+    SteamProperties::Output liquidProperties;
 
     if ((saturatedTemperature_ >= SteamSystemModelerTool::TEMPERATURE_MIN)
         && (saturatedTemperature_ <= SteamSystemModelerTool::TEMPERATURE_Tp)) {
@@ -55,19 +55,19 @@ std::unordered_map<std::string, double> SaturatedProperties::calculate() {
         liquidProperties = SteamSystemModelerTool::region3(saturatedTemperature_, saturatedPressure_);
     }
 
-    const double evaporationEnthalpy = gasProperties.at("specificEnthalpy") - liquidProperties.at("specificEnthalpy");
-    const double evaporationEntropy = gasProperties.at("specificEntropy") - liquidProperties.at("specificEntropy");
-    const double evaporationVolume = gasProperties.at("specificVolume") - liquidProperties.at("specificVolume");
+    const double evaporationEnthalpy = gasProperties.specificEnthalpy - liquidProperties.specificEnthalpy;
+    const double evaporationEntropy = gasProperties.specificEntropy - liquidProperties.specificEntropy;
+    const double evaporationVolume = gasProperties.specificVolume - liquidProperties.specificVolume;
 
     return {
             {"pressure", saturatedPressure_}, //pressure in MPa
             {"temperature", saturatedTemperature_}, // temperature in Kelvin
-            {"gasSpecificEnthalpy", gasProperties.at("specificEnthalpy")}, //enthalpy in kJ/kg
-            {"gasSpecificEntropy", gasProperties.at("specificEntropy")}, // entropy in kJ/kg/K
-            {"gasSpecificVolume", gasProperties.at("specificVolume")}, // volume in m³/kg
-            {"liquidSpecificEnthalpy", liquidProperties.at("specificEnthalpy")}, // enthalpy in kJ/kg
-            {"liquidSpecificEntropy", liquidProperties.at("specificEntropy")}, // entropy in kJ/kg/K
-            {"liquidSpecificVolume", liquidProperties.at("specificVolume")}, // volume in m³/kg
+            {"gasSpecificEnthalpy", gasProperties.specificEnthalpy}, //enthalpy in kJ/kg
+            {"gasSpecificEntropy", gasProperties.specificEntropy}, // entropy in kJ/kg/K
+            {"gasSpecificVolume", gasProperties.specificVolume}, // volume in m³/kg
+            {"liquidSpecificEnthalpy", liquidProperties.specificEnthalpy}, // enthalpy in kJ/kg
+            {"liquidSpecificEntropy", liquidProperties.specificEntropy}, // entropy in kJ/kg/K
+            {"liquidSpecificVolume", liquidProperties.specificVolume}, // volume in m³/kg
             {"evaporationSpecificEnthalpy", evaporationEnthalpy}, // enthalpy in kJ/kg
             {"evaporationSpecificEntropy", evaporationEntropy}, // entropy in kJ/kg/K
             {"evaporationSpecificVolume", evaporationVolume}, // volume in m³/kg

--- a/src/ssmt/SaturatedProperties.cpp
+++ b/src/ssmt/SaturatedProperties.cpp
@@ -43,7 +43,7 @@ double SaturatedPressure::calculate() const {
 
 std::unordered_map<std::string, double> SaturatedProperties::calculate() {
     auto const gasProperties = SteamSystemModelerTool::region2(saturatedTemperature_, saturatedPressure_);
-    SteamProperties::Output liquidProperties;
+    SteamSystemModelerTool::SteamPropertiesOutput liquidProperties;
 
     if ((saturatedTemperature_ >= SteamSystemModelerTool::TEMPERATURE_MIN)
         && (saturatedTemperature_ <= SteamSystemModelerTool::TEMPERATURE_Tp)) {

--- a/src/ssmt/SteamSystemModelerTool.cpp
+++ b/src/ssmt/SteamSystemModelerTool.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 
 // where t is temperature and p is pressure
-SteamProperties::Output SteamSystemModelerTool::region1(const double t, const double p) {
+SteamSystemModelerTool::SteamPropertiesOutput SteamSystemModelerTool::region1(const double t, const double p) {
 
 	static const std::array<double, 34> n = {
 			{
@@ -54,7 +54,7 @@ SteamProperties::Output SteamSystemModelerTool::region1(const double t, const do
 }
 
 // where t is temperature in K and p is pressure in MPa
-SteamProperties::Output SteamSystemModelerTool::region2(const double t, const double p) {
+SteamSystemModelerTool::SteamPropertiesOutput SteamSystemModelerTool::region2(const double t, const double p) {
 
 	static const std::array<double, 9> n0 = {
 			{
@@ -126,7 +126,7 @@ SteamProperties::Output SteamSystemModelerTool::region2(const double t, const do
 	};
 }
 
-SteamProperties::Output SteamSystemModelerTool::region3(const double t, const double p) {
+SteamSystemModelerTool::SteamPropertiesOutput SteamSystemModelerTool::region3(const double t, const double p) {
 	auto boundary13Properties = region1(TEMPERATURE_Tp, p);
 	auto densityA = boundary13Properties.density;
 	auto region3propNew = region3Density( densityA, t);
@@ -169,7 +169,7 @@ SteamProperties::Output SteamSystemModelerTool::region3(const double t, const do
 
 }
 
-SteamProperties::Output SteamSystemModelerTool::region3Density(const double d, const double t) {
+SteamSystemModelerTool::SteamPropertiesOutput SteamSystemModelerTool::region3Density(const double d, const double t) {
 
 	static const std::array<double, 40> n = {
 			{
@@ -495,7 +495,7 @@ double SteamSystemModelerTool::backwardPressureEntropyRegion2C(const double pres
 }
 
 Point SteamSystemModelerTool::generatePoint(int region, SteamSystemModelerTool::Key key, double pressure, double temperature) {
-    SteamProperties::Output result;
+    SteamSystemModelerTool::SteamPropertiesOutput result;
 
     switch (region) {
         case 1: {

--- a/src/ssmt/Turbine.cpp
+++ b/src/ssmt/Turbine.cpp
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include "ssmt/Turbine.h"
 
 Turbine::Turbine(Solve solveFor, double inletPressure, SteamProperties::ThermodynamicQuantity inletQuantity,
@@ -40,11 +41,11 @@ void Turbine::calculate() {
 
 void Turbine::solveForOutletProperties() {
 	inletProperties = SteamProperties(inletPressure, inletQuantity, inletQuantityValue).calculate();
-	auto const inletSpecificEnthalpy = inletProperties.at("specificEnthalpy");
+	auto const inletSpecificEnthalpy = inletProperties.specificEnthalpy;
 
 	outletProperties = SteamProperties(outletSteamPressure, SteamProperties::ThermodynamicQuantity::ENTROPY,
-	                                   inletProperties.at("specificEntropy")).calculate();
-	auto const idealOutletSpecificEnthalpy = outletProperties.at("specificEnthalpy");
+	                                   inletProperties.specificEntropy).calculate();
+	auto const idealOutletSpecificEnthalpy = outletProperties.specificEnthalpy;
 
 	auto const outletSpecificEnthalpy = inletSpecificEnthalpy
 	                                    - isentropicEfficiency * (inletSpecificEnthalpy - idealOutletSpecificEnthalpy);
@@ -57,19 +58,19 @@ void Turbine::solveForOutletProperties() {
 
 void Turbine::solveForIsentropicEfficiency() {
 	inletProperties = SteamProperties(inletPressure, inletQuantity, inletQuantityValue).calculate();
-	auto const inletSpecificEnthalpy = inletProperties.at("specificEnthalpy");
+	auto const inletSpecificEnthalpy = inletProperties.specificEnthalpy;
 
 	outletProperties = SteamProperties(outletSteamPressure, SteamProperties::ThermodynamicQuantity::ENTROPY,
-	                                   inletProperties.at("specificEntropy")).calculate();
-	auto const idealOutletSpecificEnthalpy = outletProperties.at("specificEnthalpy");
+	                                   inletProperties.specificEntropy).calculate();
+	auto const idealOutletSpecificEnthalpy = outletProperties.specificEnthalpy;
 
 	outletProperties = SteamProperties(outletSteamPressure, SteamProperties::ThermodynamicQuantity::TEMPERATURE,
 	                                   outletQuantityValue).calculate();
 
-	isentropicEfficiency = (inletSpecificEnthalpy - outletProperties.at("specificEnthalpy"))
+	isentropicEfficiency = (inletSpecificEnthalpy - outletProperties.specificEnthalpy)
 	                       / (inletSpecificEnthalpy - idealOutletSpecificEnthalpy);
 
-	calculateTurbineProperties(inletSpecificEnthalpy, outletProperties.at("specificEnthalpy"));
+	calculateTurbineProperties(inletSpecificEnthalpy, outletProperties.specificEnthalpy);
 }
 
 void Turbine::calculateTurbineProperties(const double inletSpecificEnthalpy, const double outletSpecificEnthalpy) {

--- a/tests/Boiler.unit.cpp
+++ b/tests/Boiler.unit.cpp
@@ -3,11 +3,11 @@
 
 TEST_CASE( "Calculate Boiler properties", "[Boiler][ssmt]") {
     auto b = Boiler(10, 85, 2, 20, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 45);
-    CHECK(b.getSteamProperties().at("steamEnergyFlow") == Approx(110.7533647509));
-    CHECK(b.getFeedwaterProperties().at("feedwaterMassFlow") == Approx(45.9183673469));
-    CHECK(b.getFeedwaterProperties().at("feedwaterEnergyFlow") == Approx(64.6469770669));
-    CHECK(b.getBlowdownProperties().at("blowdownMassFlow") == Approx(0.9183673469));
-    CHECK(b.getBlowdownProperties().at("blowdownEnergyFlow") == Approx(1.6779495529));
+    CHECK(b.getSteamProperties().energyFlow == Approx(110.7533647509));
+    CHECK(b.getFeedwaterProperties().massFlow == Approx(45.9183673469));
+    CHECK(b.getFeedwaterProperties().energyFlow == Approx(64.6469770669));
+    CHECK(b.getBlowdownProperties().massFlow == Approx(0.9183673469));
+    CHECK(b.getBlowdownProperties().energyFlow == Approx(1.6779495529));
 //    CHECK(b.getBlowdownProperties().at("quality") == Approx(0)); // Quality question: I have no idea if this is what the quality should actually be or not
     CHECK( b.getBoilerEnergy() == Approx(47.7843372368));
     CHECK(b.getFuelEnergy() == Approx(56.2168673374));

--- a/tests/Boiler.unit.cpp
+++ b/tests/Boiler.unit.cpp
@@ -8,7 +8,7 @@ TEST_CASE( "Calculate Boiler properties", "[Boiler][ssmt]") {
     CHECK(b.getFeedwaterProperties().at("feedwaterEnergyFlow") == Approx(64.6469770669));
     CHECK(b.getBlowdownProperties().at("blowdownMassFlow") == Approx(0.9183673469));
     CHECK(b.getBlowdownProperties().at("blowdownEnergyFlow") == Approx(1.6779495529));
-//    CHECK(b.getBlowdownProperties().at("quality") == Approx(0)); // I have no idea if this is what the quality should actually be or not
+//    CHECK(b.getBlowdownProperties().at("quality") == Approx(0)); // Quality question: I have no idea if this is what the quality should actually be or not
     CHECK( b.getBoilerEnergy() == Approx(47.7843372368));
     CHECK(b.getFuelEnergy() == Approx(56.2168673374));
 

--- a/tests/Deaerator.unit.cpp
+++ b/tests/Deaerator.unit.cpp
@@ -2,7 +2,7 @@
 #include <ssmt/Deaerator.h>
 
 TEST_CASE( "Calculate the Feedwater Energy Flow for Deaerator calculator #1", "[Feedwater Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getFeedwaterProperties().at("energyFlow") == Approx(23707));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getFeedwaterProperties().energyFlow == Approx(23707));
     auto d = Deaerator(0.3, 0.3, 40275, 0.25, SteamProperties::ThermodynamicQuantity::ENTROPY, 354.55, 0.5, SteamProperties::ThermodynamicQuantity::ENTROPY, 538.65);
     d.setDeaeratorPressure(0.36);
     d.setVentRate(0.2);
@@ -13,58 +13,58 @@ TEST_CASE( "Calculate the Feedwater Energy Flow for Deaerator calculator #1", "[
     d.setSteamPressure(0.4);
     d.setSteamQuantityType(SteamProperties::ThermodynamicQuantity::TEMPERATURE);
     d.setSteamQuantityValue(528.65);
-    CHECK(d.getFeedwaterProperties().at("energyFlow") == Approx(23707));
+    CHECK(d.getFeedwaterProperties().energyFlow == Approx(23707));
 }
 
 TEST_CASE( "Calculate the Vented Steam Mass Flow for Deaerator calculator #1", "[Vented Steam Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getVentedSteamProperties().at("massFlow") == Approx(80.558));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getVentedSteamProperties().massFlow == Approx(80.558));
 }
 
 TEST_CASE( "Calculate the Vented Steam Energy Flow for Deaerator calculator #1", "[Vented Steam Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getVentedSteamProperties().at("energyFlow") == Approx(220.1854575262));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getVentedSteamProperties().energyFlow == Approx(220.1854575262));
 }
 
 TEST_CASE( "Calculate the Inlet Water Mass Flow for Deaerator calculator #1", "[Inlet Water Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletWaterProperties().at("massFlow") == Approx(35929));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletWaterProperties().massFlow == Approx(35929));
 }
 
 TEST_CASE( "Calculate the Inlet Water Energy Flow for Deaerator calculator #1", "[Inlet Water Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletWaterProperties().at("energyFlow") == Approx(10742));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletWaterProperties().energyFlow == Approx(10742));
 }
 
 TEST_CASE( "Calculate the Inlet Steam Mass Flow for Deaerator calculator #1", "[Inlet Steam Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletSteamProperties().at("massFlow") == Approx(4430.7329148269));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletSteamProperties().massFlow == Approx(4430.7329148269));
 }
 
 TEST_CASE( "Calculate the Inlet Steam Energy Flow for Deaerator calculator #1", "[Inlet Steam Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletSteamProperties().at("energyFlow") == Approx(13185.2046114516));
+    CHECK( Deaerator(0.36, 0.2, 40279, 0.15, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 344.55, 0.4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 528.65).getInletSteamProperties().energyFlow == Approx(13185.2046114516));
 }
 
 TEST_CASE( "Calculate the Feedwater Energy Flow for Deaerator calculator #2", "[Feedwater Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getFeedwaterProperties().at("energyFlow") == Approx(21032));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getFeedwaterProperties().energyFlow == Approx(21032));
 }
 
 TEST_CASE( "Calculate the Vented Steam Mass Flow for Deaerator calculator #2", "[Vented Steam Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getVentedSteamProperties().at("massFlow") == Approx(166.74));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getVentedSteamProperties().massFlow == Approx(166.74));
 }
 
 TEST_CASE( "Calculate the Vented Steam Energy Flow for Deaerator calculator #2", "[Vented Steam Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getVentedSteamProperties().at("energyFlow") == Approx(451.2310290232));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getVentedSteamProperties().energyFlow == Approx(451.2310290232));
 }
 
 TEST_CASE( "Calculate the Inlet Water Mass Flow for Deaerator calculator #2", "[Inlet Water Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletWaterProperties().at("massFlow") == Approx(34305));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletWaterProperties().massFlow == Approx(34305));
 }
 
 TEST_CASE( "Calculate the Inlet Water Energy Flow for Deaerator calculator #2", "[Inlet Water Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletWaterProperties().at("energyFlow") == Approx(3430.5357797804));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletWaterProperties().energyFlow == Approx(3430.5357797804));
 }
 
 TEST_CASE( "Calculate the Inlet Steam Mass Flow for Deaerator calculator #2", "[Inlet Steam Mass Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletSteamProperties().at("massFlow") == Approx(7546.3822021967));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletSteamProperties().massFlow == Approx(7546.3822021967));
 }
 
 TEST_CASE( "Calculate the Inlet Steam Energy Flow for Deaerator calculator #2", "[Inlet Steam Energy Flow][Deaerator][ssmt]") {
-    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletSteamProperties().at("energyFlow") == Approx(18053));
+    CHECK( Deaerator(0.1998, 0.4, 41685, 0.1235, SteamProperties::ThermodynamicQuantity::ENTHALPY, 100, 0.4777, SteamProperties::ThermodynamicQuantity::ENTROPY, 6).getInletSteamProperties().energyFlow == Approx(18053));
 }
 

--- a/tests/FlashTank.unit.cpp
+++ b/tests/FlashTank.unit.cpp
@@ -2,48 +2,48 @@
 #include <ssmt/FlashTank.h>
 
 TEST_CASE( "Calculate the Inlet Water Energy Flow #1", "[Inlet Water Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getInletWaterProperties().at("energyFlow") == Approx(72266));
+    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getInletWaterProperties().energyFlow == Approx(72266));
     auto ft = FlashTank(4, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 1000, 33133, 4.3884);
 	ft.setInletWaterPressure(4.54484);
     ft.setQuantityType(SteamProperties::ThermodynamicQuantity::ENTHALPY);
     ft.setQuantityValue(2000);
     ft.setInletWaterMassFlow(36133);
 	ft.setTankPressure(4.3884);
-    CHECK( ft.getInletWaterProperties().at("energyFlow") == Approx(72266));
+    CHECK( ft.getInletWaterProperties().energyFlow == Approx(72266));
 }
 
 TEST_CASE( "Calculate the Outlet Gas Mass Flow #1", "[Outlet Gas Mass Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletSaturatedProperties().at("gasMassFlow") == Approx(19667));
+    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletGasSaturatedProperties().massFlow == Approx(19667));
 }
 
 TEST_CASE( "Calculate the Outlet Gas Energy Flow #1", "[Outlet Gas Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletSaturatedProperties().at("gasEnergyFlow") == Approx(55127));
+    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletGasSaturatedProperties().energyFlow == Approx(55127));
 }
 
 TEST_CASE( "Calculate the Outlet Liquid Mass Flow #1", "[Outlet Liquid Mass Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletSaturatedProperties().at("liquidMassFlow") == Approx(16466));
+    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletLiquidSaturatedProperties().massFlow == Approx(16466));
 }
 
 TEST_CASE( "Calculate the Outlet Liquid Energy Flow #1", "[Outlet Liquid Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletSaturatedProperties().at("liquidEnergyFlow") == Approx(17139));
+    CHECK( FlashTank(4.54484, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36133, 3.3884).getOutletLiquidSaturatedProperties().energyFlow == Approx(17139));
 }
 
 TEST_CASE( "Calculate the Inlet Water Energy Flow #2", "[Inlet Water Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getInletWaterProperties().at("energyFlow") == Approx(6921.0977318671));
+    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getInletWaterProperties().energyFlow == Approx(6921.0977318671));
 }
 
 TEST_CASE( "Calculate the Outlet Gas Mass Flow #2", "[Outlet Gas Mass Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletSaturatedProperties().at("gasMassFlow") == Approx(401.683398632));
+    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletGasSaturatedProperties().massFlow == Approx(401.683398632));
 }
 
 TEST_CASE( "Calculate the Outlet Gas Energy Flow #2", "[Outlet Gas Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletSaturatedProperties().at("gasEnergyFlow") == Approx(1119.3361991061));
+    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletGasSaturatedProperties().energyFlow == Approx(1119.3361991061));
 }
 
 TEST_CASE( "Calculate the Outlet Liquid Mass Flow #2", "[Outlet Liquid Mass Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletSaturatedProperties().at("liquidMassFlow") == Approx(7114.316601368));
+    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletLiquidSaturatedProperties().massFlow == Approx(7114.316601368));
 }
 
 TEST_CASE( "Calculate the Outlet Liquid Energy Flow #2", "[Outlet Liquid Energy Flow][FlashTank][ssmt]") {
-    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletSaturatedProperties().at("liquidEnergyFlow") == Approx(5801.761532761));
+    CHECK( FlashTank(2.1077, SteamProperties::ThermodynamicQuantity::QUALITY, 0, 7516, 1.3047).getOutletLiquidSaturatedProperties().energyFlow == Approx(5801.761532761));
 }

--- a/tests/Header.unit.cpp
+++ b/tests/Header.unit.cpp
@@ -17,10 +17,10 @@ TEST_CASE( "Calculate Header properties", "[Header][ssmt]") {
 
 	header.setInlets(inlets);
 	CHECK(header.getSpecificEnthalpy() == Approx(1941.73683349));
-	CHECK(header.getHeaderProperties().at("temperature") == Approx(388.8366691795));
-	CHECK(header.getHeaderProperties().at("quality") == Approx(0.65771447961));
+	CHECK(header.getHeaderProperties().temperature == Approx(388.8366691795));
+	CHECK(header.getHeaderProperties().quality == Approx(0.65771447961));
 
 	header.setHeaderPressure(0.15);
 	header.setHeaderPressure(0.173);
-	CHECK(header.getHeaderProperties().at("quality") == Approx(0.65771447961));
+	CHECK(header.getHeaderProperties().quality == Approx(0.65771447961));
 }

--- a/tests/HeatLoss.unit.cpp
+++ b/tests/HeatLoss.unit.cpp
@@ -2,7 +2,7 @@
 #include <ssmt/HeatLoss.h>
 
 TEST_CASE( "Calculate the Inlet Energy Flow #1", "[Inlet Energy Flow][HeatLoss][ssmt]") {
-    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getInletProperties().at("energyFlow") == Approx(15643));
+    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getInletProperties().energyFlow == Approx(15643));
 
     auto hl = HeatLoss(2.0, SteamProperties::ThermodynamicQuantity::ENTHALPY, 500, 5000, 2.0);
     hl.setInletPressure(2.418);
@@ -10,15 +10,15 @@ TEST_CASE( "Calculate the Inlet Energy Flow #1", "[Inlet Energy Flow][HeatLoss][
     hl.setQuantityValue(521);
     hl.setInletMassFlow(5434);
     hl.setPercentHeatLoss(2.44);
-    CHECK( hl.getInletProperties().at("energyFlow") == Approx(15643));
+    CHECK( hl.getInletProperties().energyFlow == Approx(15643));
 }
 
 TEST_CASE( "Calculate the Outlet Mass Flow", "[Outlet Mass Flow][HeatLoss][ssmt]") {
-    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getOutletProperties().at("massFlow") == Approx(5434));
+    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getOutletProperties().massFlow == Approx(5434));
 }
 
 TEST_CASE( "Calculate the Outlet Energy Flow #1", "[Outlet Energy Flow][HeatLoss][ssmt]") {
-    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getOutletProperties().at("energyFlow") == Approx(15261.2789453459));
+    CHECK( HeatLoss(2.418, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 521, 5434, 2.44).getOutletProperties().energyFlow == Approx(15261.2789453459));
 }
 
 TEST_CASE( "Calculate the Heat Loss #1", "[Inlet Energy Flow][HeatLoss][ssmt]") {
@@ -26,11 +26,11 @@ TEST_CASE( "Calculate the Heat Loss #1", "[Inlet Energy Flow][HeatLoss][ssmt]") 
 }
 
 TEST_CASE( "Calculate the Inlet Energy Flow #2", "[Inlet Energy Flow][HeatLoss][ssmt]") {
-    CHECK( HeatLoss(5.1414, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36011, 3.11).getInletProperties().at("energyFlow") == Approx(72022));
+    CHECK( HeatLoss(5.1414, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36011, 3.11).getInletProperties().energyFlow == Approx(72022));
 }
 
 TEST_CASE( "Calculate the Outlet Energy Flow #2", "[Outlet Energy Flow][HeatLoss][ssmt]") {
-    CHECK( HeatLoss(5.1414, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36011, 3.11).getOutletProperties().at("energyFlow") == Approx(69782));
+    CHECK( HeatLoss(5.1414, SteamProperties::ThermodynamicQuantity::ENTHALPY, 2000, 36011, 3.11).getOutletProperties().energyFlow == Approx(69782));
 }
 
 TEST_CASE( "Calculate the Heat Loss #2", "[Heat Loss][HeatLoss][ssmt]") {

--- a/tests/PRV.unit.cpp
+++ b/tests/PRV.unit.cpp
@@ -21,8 +21,8 @@ TEST_CASE( "Calculate the Outlet Energy Flow without Desuperheating", "[Outlet E
 }
 
 TEST_CASE( "Calculate the Outlet Temperature without Desuperheating", "[Outlet Temperature][PRV][ssmt]") {
-    std::unordered_map <std::string, double> props = PrvWithoutDesuperheating(4.8794, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 691.5, 37970, 4.0823).getOutletProperties();
-    CHECK( props.at("temperature") == Approx(686.0087848902));
+    auto const props = PrvWithoutDesuperheating(4.8794, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 691.5, 37970, 4.0823).getOutletProperties();
+    CHECK( props.temperature == Approx(686.0087848902));
 }
 
 TEST_CASE( "Calculate the Inlet Energy Flow with Desuperheating", "[Inlet Energy Flow][PRV][ssmt]") {

--- a/tests/SaturatedProperties.unit.cpp
+++ b/tests/SaturatedProperties.unit.cpp
@@ -13,72 +13,72 @@ TEST_CASE( "Calculate the Saturated Pressure from Temperature", "[Saturated Pres
 
 TEST_CASE( "Calculate the Saturated Gas Specific Enthalpy", "[Gas Enthalpy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20, 638.8959115457);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["gasSpecificEnthalpy"] == Approx(2421.6805426877));
+    auto const props = sp.calculate();
+    CHECK( props.gasSpecificEnthalpy == Approx(2421.6805426877));
 }
 
 TEST_CASE( "Calculate the Saturated Gas Specific Entropy", "[Gas Entropy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20, 638.8959115457);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["gasSpecificEntropy"] == Approx(4.946));
+    auto const props = sp.calculate();
+    CHECK( props.gasSpecificEntropy == Approx(4.946));
 }
 
 TEST_CASE( "Calculate the Saturated Gas Specific Volume", "[Gas Volume][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20, 638.8959115457);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["gasSpecificVolume"] == Approx(0.0059368541));
+    auto const props = sp.calculate();
+    CHECK( props.gasSpecificVolume == Approx(0.0059368541));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Enthalpy (Region 1)", "[Liquid Enthalpy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificEnthalpy"] == Approx(112.5749908124));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificEnthalpy == Approx(112.5749908124));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Entropy (Region 1)", "[Liquid Entropy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificEntropy"] == Approx(0.3931236015));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificEntropy == Approx(0.3931236015));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Volume (Region 1)", "[Liquid Volume][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificVolume"] == Approx(0.001));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificVolume == Approx(0.001));
 }
 
 TEST_CASE( "Calculate the Evaporation Specific Volume", "[Evaporation Volume][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["evaporationSpecificVolume"] == Approx(39.081));
+    auto const props = sp.calculate();
+    CHECK( props.evaporationSpecificVolume == Approx(39.081));
 }
 
 TEST_CASE( "Calculate the Evaporation Specific Enthalpy", "[Evaporation Enthalpy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["evaporationSpecificEnthalpy"] == Approx(2437.3));
+    auto const props = sp.calculate();
+    CHECK( props.evaporationSpecificEnthalpy == Approx(2437.3));
 }
 
 TEST_CASE( "Calculate the Evaporation Specific Entropy", "[Evaporation Entropy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(0.0035365894, 300);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["evaporationSpecificEntropy"] == Approx(8.1244130853));
+    auto const props = sp.calculate();
+    CHECK( props.evaporationSpecificEntropy == Approx(8.1244130853));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Volume (Region 3)", "[Liquid Volume][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20.2659, 640);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificVolume"] == Approx(0.0020763677));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificVolume == Approx(0.0020763677));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Enthalpy (Region 3)", "[Liquid Enthalpy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20.2659, 640);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificEnthalpy"] == Approx(1841.9862103902));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificEnthalpy == Approx(1841.9862103902));
 }
 
 TEST_CASE( "Calculate the Saturated Liquid Specific Entropy (Region 3)", "[Liquid Entropy][ssmt][Calculator]") {
     SaturatedProperties sp = SaturatedProperties(20.2659, 640);
-    std::unordered_map <std::string, double> props = sp.calculate();
-    CHECK( props["liquidSpecificEntropy"] == Approx(4.0378047547));
+    auto const props = sp.calculate();
+    CHECK( props.liquidSpecificEntropy == Approx(4.0378047547));
 }

--- a/tests/SteamProperties.unit.cpp
+++ b/tests/SteamProperties.unit.cpp
@@ -4,31 +4,31 @@
 
 //TEST_CASE( "region 1", "[region 1]") {
 //	auto result = SteamSystemModelerTool::region1(300, 15);
-//	CHECK( result["pressure"] == Approx(15.0));
-//	CHECK( result["temperature"] == Approx(300));
-//	CHECK( result["specificEnthalpy"] == Approx(126.3055708813));
-//	CHECK( result["specificEntropy"] == Approx(0.3888958577));
-//	CHECK( result["quality"] == Approx(0));
-//	CHECK( result["specificVolume"] == Approx(0.0009968749));
+//	CHECK( result.pressure == Approx(15.0));
+//	CHECK( result.temperature == Approx(300));
+//	CHECK( result.specificEnthalpy == Approx(126.3055708813));
+//	CHECK( result.specificEntropy == Approx(0.3888958577));
+//	CHECK( result.quality == Approx(0));
+//	CHECK( result.specificVolume == Approx(0.0009968749));
 //
 //	result = SteamSystemModelerTool::region1(SteamSystemModelerTool::TEMPERATURE_Tp, 25.58);
-//	CHECK( result["pressure"] == Approx(25.58));
-//	CHECK( result["temperature"] == Approx(623.15));
-//	CHECK( result["specificEnthalpy"] == Approx(1621.84698));
-//	CHECK( result["specificEntropy"] == Approx(3.6756));
-//	CHECK( result["specificVolume"] == Approx(0.001592707));
-//	CHECK( result["density"] == Approx(627.8616834));
+//	CHECK( result.pressure == Approx(25.58));
+//	CHECK( result.temperature == Approx(623.15));
+//	CHECK( result.specificEnthalpy == Approx(1621.84698));
+//	CHECK( result.specificEntropy == Approx(3.6756));
+//	CHECK( result.specificVolume == Approx(0.001592707));
+//	CHECK( result.density == Approx(627.8616834));
 //}
 //
 //TEST_CASE( "region3Density", "[region3Density]") {
 //	auto result = SteamSystemModelerTool::region3Density(627.8616834, 650);
-//	CHECK( result["pressure"] == Approx(46.90039363463));
-//	CHECK( result["temperature"] == Approx(650));
-//	CHECK( result["specificVolume"] == Approx(0.0015927074805465));
-//	CHECK( result["density"] == Approx(627.86168346299));
-//	CHECK( result["specificEnthalpy"] == Approx(1734.6938311862));
-//	CHECK( result["specificEntropy"] == Approx(3.7995608137168));
-//	CHECK( result["internalEnergy"] == Approx(1659.9952234038));
+//	CHECK( result.pressure == Approx(46.90039363463));
+//	CHECK( result.temperature == Approx(650));
+//	CHECK( result.specificVolume == Approx(0.0015927074805465));
+//	CHECK( result.density == Approx(627.86168346299));
+//	CHECK( result.specificEnthalpy == Approx(1734.6938311862));
+//	CHECK( result.specificEntropy == Approx(3.7995608137168));
+//	CHECK( result.internalEnergy == Approx(1659.9952234038));
 //}
 //
 //TEST_CASE( "boundaryByPressureRegion3to2", "[boundaryByPressureRegion3to2]") {
@@ -38,278 +38,278 @@
 //
 //TEST_CASE( "region 2", "[region 2]") {
 //	auto result = SteamSystemModelerTool::region2(679.50438021013, 25.58);
-//	CHECK( result["pressure"] == Approx(25.58));
-//	CHECK( result["temperature"] == Approx(679.50438021013));
-//	CHECK( result["specificVolume"] == Approx(0.006211616555293));
-//	CHECK( result["density"] == Approx(160.98868806509));
-//	CHECK( result["specificEnthalpy"] == Approx(2621.5406472142));
-//	CHECK( result["specificEntropy"] == Approx(5.198131771144));
+//	CHECK( result.pressure == Approx(25.58));
+//	CHECK( result.temperature == Approx(679.50438021013));
+//	CHECK( result.specificVolume == Approx(0.006211616555293));
+//	CHECK( result.density == Approx(160.98868806509));
+//	CHECK( result.specificEnthalpy == Approx(2621.5406472142));
+//	CHECK( result.specificEntropy == Approx(5.198131771144));
 //}
 //
 //TEST_CASE( "region 3", "[region 3]") {
 //	auto result = SteamSystemModelerTool::region3(650, 25.58);
-//	CHECK( result["density"] == Approx(499.93601366213));
-//	CHECK( result["specificVolume"] == Approx(0.0020002559781097));
-//	CHECK( result["internalEnergy"] == Approx(1812.3374452641));
-//	CHECK( result["specificEnthalpy"] == Approx(1863.5039931841));
-//	CHECK( result["specificEntropy"] == Approx(4.0543976678954));
+//	CHECK( result.density == Approx(499.93601366213));
+//	CHECK( result.specificVolume == Approx(0.0020002559781097));
+//	CHECK( result.internalEnergy == Approx(1812.3374452641));
+//	CHECK( result.specificEnthalpy == Approx(1863.5039931841));
+//	CHECK( result.specificEntropy == Approx(4.0543976678954));
 //}
 
 TEST_CASE( "waterPropertiesPressureTemperature", "[waterPropertiesPressureTemp]") {
 	auto const quality = SteamProperties::ThermodynamicQuantity::TEMPERATURE;
 	auto result = SteamProperties(25.58, quality, 650).calculate();
-	CHECK( result["density"] == Approx(499.93601366213));
-	CHECK( result["specificVolume"] == Approx(0.0020002559781097));
-	CHECK( result["internalEnergy"] == Approx(1812.3374452641));
-	CHECK( result["specificEnthalpy"] == Approx(1863.5039931841));
-	CHECK( result["specificEntropy"] == Approx(4.0543976678954));
+	CHECK( result.density == Approx(499.93601366213));
+	CHECK( result.specificVolume == Approx(0.0020002559781097));
+	CHECK( result.internalEnergy == Approx(1812.3374452641));
+	CHECK( result.specificEnthalpy == Approx(1863.5039931841));
+	CHECK( result.specificEntropy == Approx(4.0543976678954));
 
 	result = SteamProperties(3, quality, 300).calculate();
-	CHECK( result["specificVolume"] == Approx(0.001));
-	CHECK( result["specificEnthalpy"] == Approx(115.3312730214));
-	CHECK( result["specificEntropy"] == Approx(0.3922947924));
+	CHECK( result.specificVolume == Approx(0.001));
+	CHECK( result.specificEnthalpy == Approx(115.3312730214));
+	CHECK( result.specificEntropy == Approx(0.3922947924));
 
 	result = SteamProperties(3, quality, 500).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(975.542239097));
-	CHECK( result["specificEntropy"] == Approx(2.5804191201));
-	CHECK( result["specificVolume"] == Approx(0.001202418));
+	CHECK( result.specificEnthalpy == Approx(975.542239097));
+	CHECK( result.specificEntropy == Approx(2.5804191201));
+	CHECK( result.specificVolume == Approx(0.001202418));
 
 	result = SteamProperties(80, quality, 300).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(184.142828));
-	CHECK( result["specificEntropy"] == Approx(0.368563852));
-	CHECK( result["specificVolume"] == Approx(0.000971181));
+	CHECK( result.specificEnthalpy == Approx(184.142828));
+	CHECK( result.specificEntropy == Approx(0.368563852));
+	CHECK( result.specificVolume == Approx(0.000971181));
 
 	result = SteamProperties(80, quality, 500).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(1005.1696722456));
-	CHECK( result["specificEntropy"] == Approx(2.4609385983));
-	CHECK( result["specificVolume"] == Approx(0.00112629));
+	CHECK( result.specificEnthalpy == Approx(1005.1696722456));
+	CHECK( result.specificEntropy == Approx(2.4609385983));
+	CHECK( result.specificVolume == Approx(0.00112629));
 
 	// region 2 areas
 	result = SteamProperties(0.0035, quality, 300).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(2549.9));
-	CHECK( result["specificEntropy"] == Approx(8.5223896673));
-	CHECK( result["specificVolume"] == Approx(39.491));
+	CHECK( result.specificEnthalpy == Approx(2549.9));
+	CHECK( result.specificEntropy == Approx(8.5223896673));
+	CHECK( result.specificVolume == Approx(39.491));
 
 	result = SteamProperties(0.0035, quality, 700).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(3335.7));
-	CHECK( result["specificEntropy"] == Approx(10.175));
-	CHECK( result["specificVolume"] == Approx(92.302));
+	CHECK( result.specificEnthalpy == Approx(3335.7));
+	CHECK( result.specificEntropy == Approx(10.175));
+	CHECK( result.specificVolume == Approx(92.302));
 
 	result = SteamProperties(30, quality, 700).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(2631.4947448448));
-	CHECK( result["specificEntropy"] == Approx(5.1754029823));
-	CHECK( result["specificVolume"] == Approx(0.0054294662));
+	CHECK( result.specificEnthalpy == Approx(2631.4947448448));
+	CHECK( result.specificEntropy == Approx(5.1754029823));
+	CHECK( result.specificVolume == Approx(0.0054294662));
 
 	result = SteamProperties(1, quality, 450).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(749.3284821858));
-	CHECK( result["specificEntropy"] == Approx(2.108854683));
-	CHECK( result["specificVolume"] == Approx(0.0011231015));
+	CHECK( result.specificEnthalpy == Approx(749.3284821858));
+	CHECK( result.specificEntropy == Approx(2.108854683));
+	CHECK( result.specificVolume == Approx(0.0011231015));
 
 	result = SteamProperties(1, quality, 440).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(705.5753461629));
-	CHECK( result["specificEntropy"] == Approx(2.0105303763));
-	CHECK( result["specificVolume"] == Approx(0.0011101036));
+	CHECK( result.specificEnthalpy == Approx(705.5753461629));
+	CHECK( result.specificEntropy == Approx(2.0105303763));
+	CHECK( result.specificVolume == Approx(0.0011101036));
 
 	result = SteamProperties(1.5, quality, 450).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(749.5873697011));
-	CHECK( result["specificEntropy"] == Approx(2.1081823281));
-	CHECK( result["specificVolume"] == Approx(0.0011226877));
+	CHECK( result.specificEnthalpy == Approx(749.5873697011));
+	CHECK( result.specificEntropy == Approx(2.1081823281));
+	CHECK( result.specificVolume == Approx(0.0011226877));
 
 	// region 3 areas
 	result = SteamProperties(25.6, quality, 650).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(1863.1063178273));
-	CHECK( result["specificEntropy"] == Approx(4.0537243346));
-	CHECK( result["specificVolume"] == Approx(0.002));
+	CHECK( result.specificEnthalpy == Approx(1863.1063178273));
+	CHECK( result.specificEntropy == Approx(4.0537243346));
+	CHECK( result.specificVolume == Approx(0.002));
 
 	result = SteamProperties(22.293064, quality, 650).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(2375.12401));
-	CHECK( result["specificEntropy"] == Approx(4.8543880077));
-	CHECK( result["specificVolume"] == Approx(0.0050000005));
+	CHECK( result.specificEnthalpy == Approx(2375.12401));
+	CHECK( result.specificEntropy == Approx(4.8543880077));
+	CHECK( result.specificVolume == Approx(0.0050000005));
 
 	result = SteamProperties(78.3, quality, 750).calculate();
-	CHECK( result["specificEnthalpy"] == Approx(2258.7326650989));
-	CHECK( result["specificEntropy"] == Approx(4.4698035205));
-	CHECK( result["specificVolume"] == Approx(0.0020001543));
+	CHECK( result.specificEnthalpy == Approx(2258.7326650989));
+	CHECK( result.specificEntropy == Approx(4.4698035205));
+	CHECK( result.specificVolume == Approx(0.0020001543));
 }
 
 TEST_CASE( "waterPropertiesPressureSpecificEnthalpy", "[waterPropertiesPressureEnthalpy]") {
 	auto sp = SteamProperties(50, SteamProperties::ThermodynamicQuantity::ENTHALPY, 60);
 	auto result = sp.calculate();
-	CHECK( result["pressure"] == Approx(50));
-	CHECK( result["temperature"] == Approx(275.8506041107));
-	CHECK( result["specificVolume"] == Approx(0.0009770201));
-	CHECK( result["specificEnthalpy"] == Approx(60.0));
-	CHECK( result["specificEntropy"] == Approx(0.0385834579));
+	CHECK( result.pressure == Approx(50));
+	CHECK( result.temperature == Approx(275.8506041107));
+	CHECK( result.specificVolume == Approx(0.0009770201));
+	CHECK( result.specificEnthalpy == Approx(60.0));
+	CHECK( result.specificEntropy == Approx(0.0385834579));
 }
 
 TEST_CASE( "waterPropertiesPressureSpecificEnthalpy2", "[waterPropertiesPressureEnthalpy2]") {
 	auto sp = SteamProperties(50, SteamProperties::ThermodynamicQuantity::ENTHALPY, 1000);
 	auto result = sp.calculate();
-	CHECK( result["pressure"] == Approx(50));
-	CHECK( result["temperature"] == Approx(501.9871417891));
-	CHECK( result["specificVolume"] == Approx( 0.0011538465));
-	CHECK( result["specificEnthalpy"] == Approx(1000.0));
-	CHECK( result["specificEntropy"] == Approx(2.5188578322));
+	CHECK( result.pressure == Approx(50));
+	CHECK( result.temperature == Approx(501.9871417891));
+	CHECK( result.specificVolume == Approx( 0.0011538465));
+	CHECK( result.specificEnthalpy == Approx(1000.0));
+	CHECK( result.specificEntropy == Approx(2.5188578322));
 }
 
 TEST_CASE( "waterPropertiesPressureSpecificEnthalpy3", "[waterPropertiesPressureEnthalpy3]") {
 	auto sp = SteamProperties(10, SteamProperties::ThermodynamicQuantity::ENTHALPY, 3000);
 	auto result = sp.calculate();
-	CHECK( result["pressure"] == Approx(10));
-	CHECK( result["temperature"] == Approx( 643.4889623134 ));
-	CHECK( result["specificVolume"] == Approx( 0.024188001 ));
-	CHECK( result["specificEnthalpy"] == Approx(3000.0100018335));
-	CHECK( result["specificEntropy"] == Approx(6.0659344202));
+	CHECK( result.pressure == Approx(10));
+	CHECK( result.temperature == Approx( 643.4889623134 ));
+	CHECK( result.specificVolume == Approx( 0.024188001 ));
+	CHECK( result.specificEnthalpy == Approx(3000.0100018335));
+	CHECK( result.specificEntropy == Approx(6.0659344202));
 }
 
 TEST_CASE( "waterPropertiesPressureSpecificEntropy", "[waterPropertiesPressureEntropy]") {
 	auto sp = SteamProperties(50, SteamProperties::ThermodynamicQuantity::ENTROPY, 3);
 	auto result = sp.calculate();
-	CHECK( result["pressure"] == Approx(50));
-	CHECK( result["temperature"] == Approx( 558.6087938578 ));
-	CHECK( result["specificVolume"] == Approx( 0.0012546044 ));
-	CHECK( result["specificEnthalpy"] == Approx(1255.054208238 ));
-	CHECK( result["specificEntropy"] == Approx( 3.0 ));
+	CHECK( result.pressure == Approx(50));
+	CHECK( result.temperature == Approx( 558.6087938578 ));
+	CHECK( result.specificVolume == Approx( 0.0012546044 ));
+	CHECK( result.specificEnthalpy == Approx(1255.054208238 ));
+	CHECK( result.specificEntropy == Approx( 3.0 ));
 }
 
 TEST_CASE( "waterPropertiesPressureSpecificQuality", "[waterPropertiesPressureQuality]") {
 	auto sp = SteamProperties(15, SteamProperties::ThermodynamicQuantity::QUALITY, 0.5);
 	auto result = sp.calculate();
-	CHECK( result["pressure"] == Approx(15));
-	CHECK( result["temperature"] == Approx(  615.307871249 ));
-	CHECK( result["specificVolume"] == Approx(0.0059985271));
-	CHECK( result["specificEnthalpy"] == Approx( 2110.5082722126 ));
-	CHECK( result["specificEntropy"] == Approx( 4.497623181 ));
+	CHECK( result.pressure == Approx(15));
+	CHECK( result.temperature == Approx(  615.307871249 ));
+	CHECK( result.specificVolume == Approx(0.0059985271));
+	CHECK( result.specificEnthalpy == Approx( 2110.5082722126 ));
+	CHECK( result.specificEntropy == Approx( 4.497623181 ));
 }
 
 TEST_CASE( "Calculate Steam Properties using Pressure and Enthalpy", "[waterPropertiesPressureEnthalpy]") {
 	auto const quality = SteamProperties::ThermodynamicQuantity::ENTHALPY;
     auto result = SteamProperties(3, quality, 500).calculate();
-    CHECK( result["pressure"] == Approx(3));
-    CHECK( result["temperature"] == Approx( 391.791991375 ));
-    CHECK( result["specificVolume"] == Approx(0.0010575419));
-    CHECK( result["specificEnthalpy"] == Approx(500 ));
-    CHECK( result["specificEntropy"] == Approx(1.5106138266 ));
+    CHECK( result.pressure == Approx(3));
+    CHECK( result.temperature == Approx( 391.791991375 ));
+    CHECK( result.specificVolume == Approx(0.0010575419));
+    CHECK( result.specificEnthalpy == Approx(500 ));
+    CHECK( result.specificEntropy == Approx(1.5106138266 ));
 
 	result = SteamProperties(80, quality, 500).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(378.1241736021));
-    CHECK( result["specificVolume"] == Approx(.001));
-    CHECK( result["specificEnthalpy"] == Approx( 500 ));
-    CHECK( result["specificEntropy"] == Approx(1.304));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(378.1241736021));
+    CHECK( result.specificVolume == Approx(.001));
+    CHECK( result.specificEnthalpy == Approx( 500 ));
+    CHECK( result.specificEntropy == Approx(1.304));
 
 	result = SteamProperties(80, quality, 1500).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(611.0580090037));
-    CHECK( result["specificVolume"] == Approx(0.0013215616));
-    CHECK( result["specificEnthalpy"] == Approx( 1500 ));
-    CHECK( result["specificEntropy"] == Approx( 3.3530707604 ));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(611.0580090037));
+    CHECK( result.specificVolume == Approx(0.0013215616));
+    CHECK( result.specificEnthalpy == Approx( 1500 ));
+    CHECK( result.specificEntropy == Approx( 3.3530707604 ));
 
 	result = SteamProperties(0.001, quality, 3000).calculate();
-	CHECK( result["pressure"] == Approx(0.001));
-	CHECK( result["temperature"] == Approx(534.433241));
-	CHECK( result["specificVolume"] == Approx(246.6488133525));
-	CHECK( result["specificEnthalpy"] == Approx( 3000 ));
-	CHECK( result["specificEntropy"] == Approx(10.2066379788));
+	CHECK( result.pressure == Approx(0.001));
+	CHECK( result.temperature == Approx(534.433241));
+	CHECK( result.specificVolume == Approx(246.6488133525));
+	CHECK( result.specificEnthalpy == Approx( 3000 ));
+	CHECK( result.specificEntropy == Approx(10.2066379788));
 
 	result = SteamProperties(3, quality, 3000).calculate();
-	CHECK( result["pressure"] == Approx(3));
-	CHECK( result["temperature"] == Approx(575.37337));
-	CHECK( result["specificVolume"] == Approx(0.0816111351));
-	CHECK( result["specificEnthalpy"] == Approx( 3000 ));
-	CHECK( result["specificEntropy"] == Approx(6.5510505695));
+	CHECK( result.pressure == Approx(3));
+	CHECK( result.temperature == Approx(575.37337));
+	CHECK( result.specificVolume == Approx(0.0816111351));
+	CHECK( result.specificEnthalpy == Approx( 3000 ));
+	CHECK( result.specificEntropy == Approx(6.5510505695));
 
 	result = SteamProperties(5, quality, 3500).calculate();
-	CHECK( result["pressure"] == Approx(5));
-	CHECK( result["temperature"] == Approx(801.299102));
-	CHECK( result["specificVolume"] == Approx(0.0714748469));
-	CHECK( result["specificEnthalpy"] == Approx(3500));
-	CHECK( result["specificEntropy"] == Approx(7.0610476389));
+	CHECK( result.pressure == Approx(5));
+	CHECK( result.temperature == Approx(801.299102));
+	CHECK( result.specificVolume == Approx(0.0714748469));
+	CHECK( result.specificEnthalpy == Approx(3500));
+	CHECK( result.specificEntropy == Approx(7.0610476389));
 
 	result = SteamProperties(25, quality, 3500).calculate();
-	CHECK( result["pressure"] == Approx(25));
-	CHECK( result["temperature"] == Approx(875.279054));
-	CHECK( result["specificVolume"] == Approx(0.0141966031));
-	CHECK( result["specificEnthalpy"] == Approx(3500));
-	CHECK( result["specificEntropy"] == Approx(6.3710455092));
+	CHECK( result.pressure == Approx(25));
+	CHECK( result.temperature == Approx(875.279054));
+	CHECK( result.specificVolume == Approx(0.0141966031));
+	CHECK( result.specificEnthalpy == Approx(3500));
+	CHECK( result.specificEntropy == Approx(6.3710455092));
 
 	result = SteamProperties(40, quality, 2700).calculate();
-	CHECK( result["pressure"] == Approx(40));
-	CHECK( result["temperature"] == Approx(743.0656225993));
-	CHECK( result["specificVolume"] == Approx(0.0045639484));
-	CHECK( result["specificEnthalpy"] == Approx(2700));
-	CHECK( result["specificEntropy"] == Approx(5.2016434761));
+	CHECK( result.pressure == Approx(40));
+	CHECK( result.temperature == Approx(743.0656225993));
+	CHECK( result.specificVolume == Approx(0.0045639484));
+	CHECK( result.specificEnthalpy == Approx(2700));
+	CHECK( result.specificEntropy == Approx(5.2016434761));
 
 	result = SteamProperties(60, quality, 2700).calculate();
-	CHECK( result["pressure"] == Approx(60));
-	CHECK( result["temperature"] == Approx(791.1146921709));
-	CHECK( result["specificVolume"] == Approx(0.003319241));
-	CHECK( result["specificEnthalpy"] == Approx(2700));
-	CHECK( result["specificEntropy"] == Approx(5.1013392134));
+	CHECK( result.pressure == Approx(60));
+	CHECK( result.temperature == Approx(791.1146921709));
+	CHECK( result.specificVolume == Approx(0.003319241));
+	CHECK( result.specificEnthalpy == Approx(2700));
+	CHECK( result.specificEntropy == Approx(5.1013392134));
 
 	result = SteamProperties(60, quality, 3200).calculate();
-	CHECK( result["pressure"] == Approx(60));
-	CHECK( result["temperature"] == Approx(882.7697090377));
-	CHECK( result["specificVolume"] == Approx(0.0049873395));
-	CHECK( result["specificEnthalpy"] == Approx(3200));
-	CHECK( result["specificEntropy"] == Approx(5.7018594072));
+	CHECK( result.pressure == Approx(60));
+	CHECK( result.temperature == Approx(882.7697090377));
+	CHECK( result.specificVolume == Approx(0.0049873395));
+	CHECK( result.specificEnthalpy == Approx(3200));
+	CHECK( result.specificEntropy == Approx(5.7018594072));
 }
 
 TEST_CASE( "Calculate Steam Properties using Pressure and Entropy", "[waterPropertiesPressureEntropy]") {
 	auto const quality = SteamProperties::ThermodynamicQuantity::ENTROPY;
     auto result = SteamProperties(3, quality, 0.5).calculate();
-    CHECK(result["pressure"] == Approx(3));
-    CHECK(result["temperature"] == Approx(307.842258));
-    CHECK(result["specificVolume"] == Approx(0.0010046046));
-    CHECK(result["specificEnthalpy"] == Approx(148.0634883148));
-    CHECK(result["specificEntropy"] == Approx(0.5));
+    CHECK(result.pressure == Approx(3));
+    CHECK(result.temperature == Approx(307.842258));
+    CHECK(result.specificVolume == Approx(0.0010046046));
+    CHECK(result.specificEnthalpy == Approx(148.0634883148));
+    CHECK(result.specificEntropy == Approx(0.5));
 
 	result = SteamProperties(80, quality, 0.5).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(309.979785));
-    CHECK( result["specificVolume"] == Approx(0.0009747722));
-    CHECK( result["specificEnthalpy"] == Approx(224.2263328394));
-    CHECK( result["specificEntropy"] == Approx(0.5));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(309.979785));
+    CHECK( result.specificVolume == Approx(0.0009747722));
+    CHECK( result.specificEnthalpy == Approx(224.2263328394));
+    CHECK( result.specificEntropy == Approx(0.5));
 
 	result = SteamProperties(80, quality, 3).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(565.9070416669));
-    CHECK( result["specificVolume"] == Approx(0.0012263315));
-    CHECK( result["specificEnthalpy"] == Approx(1292.2544898841));
-    CHECK( result["specificEntropy"] == Approx(3));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(565.9070416669));
+    CHECK( result.specificVolume == Approx(0.0012263315));
+    CHECK( result.specificEnthalpy == Approx(1292.2544898841));
+    CHECK( result.specificEntropy == Approx(3));
 
 	result = SteamProperties(8, quality, 6).calculate();
-    CHECK( result["pressure"] == Approx(8));
-    CHECK( result["temperature"] == Approx(600.48404));
-    CHECK( result["specificVolume"] == Approx(0.0276660137));
-    CHECK( result["specificEnthalpy"] == Approx(2907.378739685));
-    CHECK( result["specificEntropy"] == Approx(6));
+    CHECK( result.pressure == Approx(8));
+    CHECK( result.temperature == Approx(600.48404));
+    CHECK( result.specificVolume == Approx(0.0276660137));
+    CHECK( result.specificEnthalpy == Approx(2907.378739685));
+    CHECK( result.specificEntropy == Approx(6));
 
 	result = SteamProperties(90, quality, 6).calculate();
-    CHECK( result["pressure"] == Approx(90));
-    CHECK( result["temperature"] == Approx(1038.01126));
-    CHECK( result["specificVolume"] == Approx(0.00454352));
-    CHECK( result["specificEnthalpy"] == Approx(3628.089478129));
-    CHECK( result["specificEntropy"] == Approx(6));
+    CHECK( result.pressure == Approx(90));
+    CHECK( result.temperature == Approx(1038.01126));
+    CHECK( result.specificVolume == Approx(0.00454352));
+    CHECK( result.specificEnthalpy == Approx(3628.089478129));
+    CHECK( result.specificEntropy == Approx(6));
 
 	result = SteamProperties(20, quality, 5.75).calculate();
-    CHECK( result["pressure"] == Approx(20));
-    CHECK( result["temperature"] == Approx(697.992849));
-    CHECK( result["specificVolume"] == Approx(0.0114675187));
-    CHECK( result["specificEnthalpy"] == Approx(2952.1269382186));
-    CHECK( result["specificEntropy"] == Approx(5.75));
+    CHECK( result.pressure == Approx(20));
+    CHECK( result.temperature == Approx(697.992849));
+    CHECK( result.specificVolume == Approx(0.0114675187));
+    CHECK( result.specificEnthalpy == Approx(2952.1269382186));
+    CHECK( result.specificEntropy == Approx(5.75));
 
 	result = SteamProperties(80, quality, 5.25).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(854.011484));
-    CHECK( result["specificVolume"] == Approx(0.0031462467));
-    CHECK( result["specificEnthalpy"] == Approx(2886.747071315));
-    CHECK( result["specificEntropy"] == Approx(5.25));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(854.011484));
+    CHECK( result.specificVolume == Approx(0.0031462467));
+    CHECK( result.specificEnthalpy == Approx(2886.747071315));
+    CHECK( result.specificEntropy == Approx(5.25));
 
 	result = SteamProperties(80, quality, 5.75).calculate();
-    CHECK( result["pressure"] == Approx(80));
-    CHECK( result["temperature"] == Approx(949.017998));
-    CHECK( result["specificVolume"] == Approx(0.0042610579));
-    CHECK( result["specificEnthalpy"] == Approx(3335.9653473966));
-    CHECK( result["specificEntropy"] == Approx(5.75));
+    CHECK( result.pressure == Approx(80));
+    CHECK( result.temperature == Approx(949.017998));
+    CHECK( result.specificVolume == Approx(0.0042610579));
+    CHECK( result.specificEnthalpy == Approx(3335.9653473966));
+    CHECK( result.specificEntropy == Approx(5.75));
 }

--- a/tests/Turbine.unit.cpp
+++ b/tests/Turbine.unit.cpp
@@ -6,20 +6,20 @@ TEST_CASE( "Turbine", "[Turbine]") {
 
 	auto t = Turbine(Turbine::Solve::OutletProperties, 4.2112, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 888,
 	                 Turbine::TurbineProperty::MassFlow, 40.1, 94.2, 15844, 3.4781);
-	CHECK( t.getInletProperties().at("specificEnthalpy") == Approx(3707.3971175332));
-	CHECK( t.getInletProperties().at("specificEntropy") == Approx(7.384097768));
+	CHECK( t.getInletProperties().specificEnthalpy == Approx(3707.3971175332));
+	CHECK( t.getInletProperties().specificEntropy == Approx(7.384097768));
 	CHECK( t.getInletEnergyFlow() == Approx(58739.99993));
 	CHECK( t.getEnergyOut() == Approx(479.1499));
 	CHECK( t.getPowerOut() == Approx(451.35921));
 
 	t = Turbine(Turbine::Solve::OutletProperties, 4.2112, SteamProperties::ThermodynamicQuantity::TEMPERATURE, 888,
 	            Turbine::TurbineProperty::PowerOut, 40.1, 94.2, 1000, 3.4781);
-	CHECK( t.getInletProperties().at("specificEnthalpy") == Approx(3707.3971175332));
-	CHECK( t.getInletProperties().at("specificEntropy") == Approx(7.384097768));
+	CHECK( t.getInletProperties().specificEnthalpy == Approx(3707.3971175332));
+	CHECK( t.getInletProperties().specificEntropy == Approx(7.384097768));
 	CHECK( t.getInletEnergyFlow() == Approx(130140));
 
-	CHECK( t.getOutletProperties().at("specificEnthalpy") == Approx(3677.1553917556));
-	CHECK( t.getOutletProperties().at("specificEntropy") == Approx(7.4364791785));
+	CHECK( t.getOutletProperties().specificEnthalpy == Approx(3677.1553917556));
+	CHECK( t.getOutletProperties().specificEntropy == Approx(7.4364791785));
 	CHECK( t.getOutletEnergyFlow() == Approx(129079));
 	CHECK( t.getMassFlow() == Approx(35.1028619554));
 	CHECK( t.getEnergyOut() == Approx(1061.5711252654));
@@ -30,12 +30,12 @@ TEST_CASE( "Turbine", "[Turbine]") {
 	            824.7, Turbine::TurbineProperty::MassFlow, 88.1, 28581, 0.5846,
 	            SteamProperties::ThermodynamicQuantity::TEMPERATURE, 623.8);
 
-	CHECK( t.getInletProperties().at("specificEnthalpy") == Approx(3551));
-	CHECK( t.getInletProperties().at("specificEntropy") == Approx(7.0935165312));
+	CHECK( t.getInletProperties().specificEnthalpy == Approx(3551));
+	CHECK( t.getInletProperties().specificEntropy == Approx(7.0935165312));
 	CHECK( t.getInletEnergyFlow() == Approx(101491.776));
 
-	CHECK( t.getOutletProperties().at("specificEnthalpy") == Approx(3167.7566746314));
-	CHECK( t.getOutletProperties().at("specificEntropy") == Approx(7.5625702284));
+	CHECK( t.getOutletProperties().specificEnthalpy == Approx(3167.7566746314));
+	CHECK( t.getOutletProperties().specificEntropy == Approx(7.5625702284));
 	CHECK( t.getOutletEnergyFlow() == Approx(90538));
 	CHECK( t.getMassFlow() == Approx(28.581));
 	CHECK( t.getEnergyOut() == Approx(10954.12251));
@@ -45,12 +45,12 @@ TEST_CASE( "Turbine", "[Turbine]") {
 	            824.7, Turbine::TurbineProperty::PowerOut, 88.1, 1000, 0.5846,
 	            SteamProperties::ThermodynamicQuantity::TEMPERATURE, 623.8);
 
-	CHECK( t.getInletProperties().at("specificEnthalpy") == Approx(3551));
-	CHECK( t.getInletProperties().at("specificEntropy") == Approx(7.0935165312));
+	CHECK( t.getInletProperties().specificEnthalpy == Approx(3551));
+	CHECK( t.getInletProperties().specificEntropy == Approx(7.0935165312));
 	CHECK( t.getInletEnergyFlow() == Approx(10516.6482999));
 
-	CHECK( t.getOutletProperties().at("specificEnthalpy") == Approx(3167.7566746314));
-	CHECK( t.getOutletProperties().at("specificEntropy") == Approx(7.5625702284));
+	CHECK( t.getOutletProperties().specificEnthalpy == Approx(3167.7566746314));
+	CHECK( t.getOutletProperties().specificEntropy == Approx(7.5625702284));
 	CHECK( t.getOutletEnergyFlow() == Approx(9381.57452));
 	CHECK( t.getMassFlow() == Approx(2.9615830645));
 	CHECK( t.getEnergyOut() == Approx(1135.0737797957));


### PR DESCRIPTION
connect #216 

- Refactor SteamProperties, SaturatedProperties, and FluidProperties outputs to be compile time enforceable
- Catch potential thrown runtime exceptions in the NAN bindings for steam

