### PR TITLE
Relative Humidity BaseGasDensity Input

### DIFF
--- a/include/fans/Fan203.h
+++ b/include/fans/Fan203.h
@@ -54,7 +54,7 @@ public:
 		double const satPress = calculateSaturationPressure(tdo);
 		double rh = 0;
 		if (inputType == InputType::RelativeHumidity) {
-			rh = relativeHumidityOrDewPoint;
+			rh = relativeHumidityOrDewPoint / 100;
 		} else if (inputType == InputType::DewPoint) {
 			rh = calculateSaturationPressure(relativeHumidityOrDewPoint) / satPress;
 		} else if (inputType == InputType::WetBulbTemp) {

--- a/tests/Fan.unit.cpp
+++ b/tests/Fan.unit.cpp
@@ -162,3 +162,10 @@ TEST_CASE( "FanCurve", "[Fan203][FanCurve]") {
 		compareRows(results2[i], expected[i]);
 	}
 }
+
+TEST_CASE( "BaseGasDensity", "[BaseGasDensity]") {
+	auto const bdg = BaseGasDensity(
+			70, 26.62, 29.92, 60, BaseGasDensity::GasType::AIR, BaseGasDensity::InputType::RelativeHumidity, 1
+	);
+	CHECK(bdg.getGasDensity() == Approx(0.08143));
+}

--- a/tests/js/fanTest.js
+++ b/tests/js/fanTest.js
@@ -228,7 +228,7 @@ test('getBaseGasDensity', function (t) {
         gasDensity: 0.0547,
         gasType: 'AIR',
         inputType: 'relativeHumidity',
-        relativeHumidity: 0.35,
+        relativeHumidity: 35,
         specificGravity: 1.05
     };
 


### PR DESCRIPTION
connects #276 

- Divide by 100 when relative humidity is given as input to BaseGasDensity
- Add one C++ unit test and update the javascript to pass 35 instead of 0.35

