### PR TITLE
ssmt.h: extract NAN/v8 data converter methods

### DIFF
--- a/bindings/NanDataConverters.h
+++ b/bindings/NanDataConverters.h
@@ -1,0 +1,143 @@
+#ifndef AMO_TOOLS_SUITE_NANDATACONVERTERS_H
+#define AMO_TOOLS_SUITE_NANDATACONVERTERS_H
+
+#include <nan.h>
+#include <node.h>
+#include <iostream>
+
+using namespace Nan;
+using namespace v8;
+
+Local <Object> inp;
+Local <Object> r;
+
+/**
+ * Get the value for the specified name from the specified object.
+ * @param name Name (variable name) of the value on the specified object.
+ * @param sourceObject The specified object to get the value from.
+ * @return The object.
+ */
+Local <Value> getValue(std::string const &name, Local <Object> sourceObject) {
+    if (sourceObject.IsEmpty()) {
+        auto msg = std::string(
+                "getValue: sourceObject is empty/does not exist; trying to get value name=" + name).c_str();
+        std::cout << msg << std::endl;
+
+        ThrowTypeError(msg);
+    }
+
+    Local <String> localName = Nan::New<String>(name).ToLocalChecked();
+    Local <Value> value = sourceObject->Get(localName);
+    if (value->IsUndefined()) {
+        auto msg = std::string("getValue method in ssmt.h: " + name + " not present in sourceObject").c_str();
+        std::cout << "getValue: " << msg << std::endl;
+
+        ThrowTypeError(msg);
+    }
+    return value;
+}
+
+/**
+ * Get the object for the specified name from the specified object.
+ * @param name Name (variable name) of the object on the specified object.
+ * @param sourceObject The specified object to get the object from.
+ * @return The object.
+ */
+Local <Object> getObject(std::string const &name, Local <Object> sourceObject) {
+    Local <Value> value = getValue(name, sourceObject);
+    return value->ToObject();
+}
+
+/**
+ * Get the object for the specified name from the root input object (inp).
+ * @param name Name (variable name) of the object.
+ * @return The object.
+ */
+Local <Object> getObject(std::string const &name) {
+    return getObject(name, inp);
+}
+
+/**
+ * Get the double value for the specified name from the specified object.
+ * @param name Name (variable name) of the value.
+ * @param sourceObject The specified object to get the double value from.
+ * @return The value as a double.
+ */
+double getDouble(std::string const &name, Local <Object> sourceObject) {
+    Local <Value> value = getValue(name, sourceObject);
+    return value->NumberValue();
+}
+
+/**
+ * Get the double value for the specified name from the root input object (inp).
+ * @param name Name (variable name) of the value.
+ * @return The value as a double.
+ */
+double getDouble(std::string const &name) {
+    return getDouble(name, inp);
+}
+
+/**
+ * Get the boolean value for the specified name from the specified object.
+ * @param name Name (variable name) of the value.
+ * @param sourceObject The specified object to get the boolean value from.
+ * @return The value as a bool.
+ */
+bool getBool(std::string const &name, Local <Object> sourceObject) {
+    Local <Value> value = getValue(name, sourceObject);
+    return value->BooleanValue();
+}
+
+/**
+ * Get the boolean value for the specified name from the root input object (inp).
+ * @param name Name (variable name) of the value.
+ * @return The value as a bool.
+ */
+bool getBool(std::string const &name) {
+    return getBool(name, inp);
+}
+
+/**
+ * Get the integer value for the specified name from the specified object.
+ * @param name Name (variable name) of the value.
+ * @param sourceObject The specified object to get the integer value from.
+ * @return The value as a integer.
+ */
+int getInteger(std::string const &name, Local <Object> sourceObject) {
+    Local <Value> value = getValue(name, sourceObject);
+    return value->IntegerValue();
+}
+
+/**
+ * Get the integer value for the specified name from the root input object (inp).
+ * @param name Name (variable name) of the value.
+ * @return The value as an integer.
+ */
+int getInteger(std::string const &name) {
+    return getInteger(name, inp);
+}
+
+/**
+ * Get the array for the specified name from the specified object.
+ * @param name Name (variable name) of the array.
+ * @param sourceObject The specified object to get the array from.
+ * @return The value as a array.
+ */
+Local <Array> getArray(std::string const &name, Local <Object> sourceObject) {
+    Local <Value> value = getValue(name, sourceObject);
+    Local <Array> array = Local<Array>::Cast(value);
+
+    return array;
+}
+
+void setRobject(std::string const &name, double number, Local <Object> obj) {
+    Local <String> localName = Nan::New<String>(name).ToLocalChecked();
+    Local <Number> localNumber = Nan::New<Number>(number);
+    Nan::Set(obj, localName, localNumber);
+}
+
+void setR(std::string const &name, double number) {
+    setRobject(name, number, r);
+}
+
+#endif //AMO_TOOLS_SUITE_NANDATACONVERTERS_H

--- a/bindings/ssmt.h
+++ b/bindings/ssmt.h
@@ -1,9 +1,8 @@
 #ifndef AMO_TOOLS_SUITE_SSMT_H
 #define AMO_TOOLS_SUITE_SSMT_H
 
-#include <nan.h>
-#include <node.h>
-#include <iostream>
+#include "NanDataConverters.h"
+
 #include "ssmt/SaturatedProperties.h"
 #include "ssmt/SteamSystemModelerTool.h"
 #include "ssmt/SteamProperties.h"
@@ -20,141 +19,6 @@
 #include <stdexcept>
 #include <array>
 #include <cmath>
-
-using namespace Nan;
-using namespace v8;
-
-Local <Object> inp;
-Local <Object> r;
-
-/**
- * Get the value for the specified name from the specified object.
- * @param name Name (variable name) of the value on the specified object.
- * @param sourceObject The specified object to get the value from.
- * @return The object.
- */
-Local <Value> getValue(std::string const &name, Local <Object> sourceObject) {
-    if (sourceObject.IsEmpty()) {
-        auto msg = std::string(
-                "getValue: sourceObject is empty/does not exist; trying to get value name=" + name).c_str();
-        std::cout << msg << std::endl;
-
-        ThrowTypeError(msg);
-    }
-
-    Local <String> localName = Nan::New<String>(name).ToLocalChecked();
-    Local <Value> value = sourceObject->Get(localName);
-    if (value->IsUndefined()) {
-        auto msg = std::string("getValue method in ssmt.h: " + name + " not present in sourceObject").c_str();
-        std::cout << "getValue: " << msg << std::endl;
-
-        ThrowTypeError(msg);
-    }
-    return value;
-}
-
-/**
- * Get the object for the specified name from the specified object.
- * @param name Name (variable name) of the object on the specified object.
- * @param sourceObject The specified object to get the object from.
- * @return The object.
- */
-Local <Object> getObject(std::string const &name, Local <Object> sourceObject) {
-    Local <Value> value = getValue(name, sourceObject);
-    return value->ToObject();
-}
-
-/**
- * Get the object for the specified name from the root input object (inp).
- * @param name Name (variable name) of the object.
- * @return The object.
- */
-Local <Object> getObject(std::string const &name) {
-    return getObject(name, inp);
-}
-
-/**
- * Get the double value for the specified name from the specified object.
- * @param name Name (variable name) of the value.
- * @param sourceObject The specified object to get the double value from.
- * @return The value as a double.
- */
-double getDouble(std::string const &name, Local <Object> sourceObject) {
-    Local <Value> value = getValue(name, sourceObject);
-    return value->NumberValue();
-}
-
-/**
- * Get the double value for the specified name from the root input object (inp).
- * @param name Name (variable name) of the value.
- * @return The value as a double.
- */
-double getDouble(std::string const &name) {
-    return getDouble(name, inp);
-}
-
-/**
- * Get the boolean value for the specified name from the specified object.
- * @param name Name (variable name) of the value.
- * @param sourceObject The specified object to get the boolean value from.
- * @return The value as a bool.
- */
-bool getBool(std::string const &name, Local <Object> sourceObject) {
-    Local <Value> value = getValue(name, sourceObject);
-    return value->BooleanValue();
-}
-
-/**
- * Get the boolean value for the specified name from the root input object (inp).
- * @param name Name (variable name) of the value.
- * @return The value as a bool.
- */
-bool getBool(std::string const &name) {
-    return getBool(name, inp);
-}
-
-/**
- * Get the integer value for the specified name from the specified object.
- * @param name Name (variable name) of the value.
- * @param sourceObject The specified object to get the integer value from.
- * @return The value as a integer.
- */
-int getInteger(std::string const &name, Local <Object> sourceObject) {
-    Local <Value> value = getValue(name, sourceObject);
-    return value->IntegerValue();
-}
-
-/**
- * Get the integer value for the specified name from the root input object (inp).
- * @param name Name (variable name) of the value.
- * @return The value as an integer.
- */
-int getInteger(std::string const &name) {
-    return getInteger(name, inp);
-}
-
-/**
- * Get the array for the specified name from the specified object.
- * @param name Name (variable name) of the array.
- * @param sourceObject The specified object to get the array from.
- * @return The value as a array.
- */
-Local <Array> getArray(std::string const &name, Local <Object> sourceObject) {
-    Local <Value> value = getValue(name, sourceObject);
-    Local <Array> array = Local<Array>::Cast(value);
-
-    return array;
-}
-
-void setRobject(std::string const &name, double number, Local <Object> obj) {
-    Local <String> localName = Nan::New<String>(name).ToLocalChecked();
-    Local <Number> localNumber = Nan::New<Number>(number);
-    Nan::Set(obj, localName, localNumber);
-}
-
-void setR(std::string const &name, double number) {
-    setRobject(name, number, r);
-}
 
 SteamProperties::ThermodynamicQuantity thermodynamicQuantity() {
     unsigned val = static_cast<unsigned>(getDouble("thermodynamicQuantity"));
@@ -305,7 +169,6 @@ NAN_METHOD(saturatedPropertiesGivenPressure) {
     setR("evaporationVolume", results.evaporationSpecificVolume);
     info.GetReturnValue().Set(r);
 }
-
 
 NAN_METHOD(steamProperties) {
     inp = info[0]->ToObject();
@@ -491,7 +354,6 @@ NAN_METHOD(prvWithoutDesuperheating) {
 }
 
 NAN_METHOD(prvWithDesuperheating) {
-
     inp = info[0]->ToObject();
     r = Nan::New<Object>();
 


### PR DESCRIPTION
* Focus ssmt.h on only steam-specific items, not general functions.
* Enables reuse - these methods are duplicated in other files.