### PR TITLE
Fix Turbine::calculateTurbineProperties #363

### DIFF
--- a/src/ssmt/Turbine.cpp
+++ b/src/ssmt/Turbine.cpp
@@ -79,8 +79,8 @@ void Turbine::calculateTurbineProperties(const double inletSpecificEnthalpy, con
 		massFlow = energyOut / (inletSpecificEnthalpy - outletSpecificEnthalpy);
 		powerOut = massFlowOrPowerOut;
 	} else {
-		massFlow = massFlowOrPowerOut / 1000;
-		energyOut = (inletSpecificEnthalpy - outletSpecificEnthalpy) * massFlow;
+		massFlow = massFlowOrPowerOut;
+		energyOut = (inletSpecificEnthalpy - outletSpecificEnthalpy) * massFlow / 1000;
 		powerOut = energyOut * generatorEfficiency;
 	}
 

--- a/tests/Turbine.unit.cpp
+++ b/tests/Turbine.unit.cpp
@@ -8,7 +8,7 @@ TEST_CASE( "Turbine", "[Turbine]") {
 	                 Turbine::TurbineProperty::MassFlow, 40.1, 94.2, 15844, 3.4781);
 	CHECK( t.getInletProperties().specificEnthalpy == Approx(3707.3971175332));
 	CHECK( t.getInletProperties().specificEntropy == Approx(7.384097768));
-	CHECK( t.getInletEnergyFlow() == Approx(58739.99993));
+	CHECK( t.getInletEnergyFlow() == Approx(58739999.9301967993));
 	CHECK( t.getEnergyOut() == Approx(479.1499));
 	CHECK( t.getPowerOut() == Approx(451.35921));
 
@@ -32,12 +32,12 @@ TEST_CASE( "Turbine", "[Turbine]") {
 
 	CHECK( t.getInletProperties().specificEnthalpy == Approx(3551));
 	CHECK( t.getInletProperties().specificEntropy == Approx(7.0935165312));
-	CHECK( t.getInletEnergyFlow() == Approx(101491.776));
+	CHECK( t.getInletEnergyFlow() == Approx(101491776.0236083418));
 
 	CHECK( t.getOutletProperties().specificEnthalpy == Approx(3167.7566746314));
 	CHECK( t.getOutletProperties().specificEntropy == Approx(7.5625702284));
-	CHECK( t.getOutletEnergyFlow() == Approx(90538));
-	CHECK( t.getMassFlow() == Approx(28.581));
+	CHECK( t.getOutletEnergyFlow() == Approx(90537653.5176413357));
+	CHECK( t.getMassFlow() == Approx(28581.0));
 	CHECK( t.getEnergyOut() == Approx(10954.12251));
 	CHECK( t.getPowerOut() == Approx(9650.5819278));
 

--- a/tests/js/ssmtTest.js
+++ b/tests/js/ssmtTest.js
@@ -362,16 +362,16 @@ test('turbine', function (t) {
     t.equal(rnd(res.inletSpecificEnthalpy), rnd(3707.397118));
     t.equal(rnd(res.inletSpecificEntropy), rnd(7.384098));
     t.equal(rnd(res.inletQuality), rnd(1));
-    t.equal(rnd(res.inletEnergyFlow), rnd(58739.99993));
+    t.equal(rnd(res.inletEnergyFlow), rnd(58739999.930197));
 
     t.equal(rnd(res.outletPressure), rnd(3.4781));
     t.equal(rnd(res.outletTemperature), rnd(872.338861));
     t.equal(rnd(res.outletSpecificEnthalpy), rnd(3677.155392));
     t.equal(rnd(res.outletSpecificEntropy), rnd(7.436479));
     t.equal(rnd(res.outletQuality), rnd(1));
-    t.equal(rnd(res.outletEnergyFlow), rnd(58260.850027));
+    t.equal(rnd(res.outletEnergyFlow), rnd(58260850.026976));
 
-    t.equal(rnd(res.massFlow), rnd(15.844));
+    t.equal(rnd(res.massFlow), rnd(15844));
     t.equal(rnd(res.isentropicEfficiency), rnd(40.1));
     t.equal(rnd(res.energyOut), rnd(479.149903));
     t.equal(rnd(res.powerOut), rnd(451.359209));
@@ -409,7 +409,7 @@ test('turbine', function (t) {
 
 });
 
-test('heatExchanger', function(t) { 
+test('heatExchanger', function(t) {
     t.plan(32);
 
     input = {


### PR DESCRIPTION
For MassFlow calc, it divides massFlow by 1000 and should not.
The energyOut formula requires this, but not massFlow.

Move the divide by 1000 from massflow to energyout formula.
