### PR TITLE
Header::calculate: fix specificEnthalpy calc #371

### DIFF
--- a/src/ssmt/Header.cpp
+++ b/src/ssmt/Header.cpp
@@ -22,7 +22,7 @@ void Header::calculate() {
 		inletMassFlow += inlet.getMassFlow();
 	}
 
-	specificEnthalpy = inletEnergyFlow / inletMassFlow;
+	specificEnthalpy = (inletMassFlow == 0.0) ? 0.0 : inletEnergyFlow / inletMassFlow;
 	headerProperties = SteamProperties(headerPressure, SteamProperties::ThermodynamicQuantity::ENTHALPY,
 	                                   specificEnthalpy).calculate();
 }
@@ -62,4 +62,3 @@ void Inlet::setQuantityType(const SteamProperties::ThermodynamicQuantity quantit
 	this->quantityType = quantityType;
 	calculate();
 }
-


### PR DESCRIPTION
Must handle inletMassFlow == 0 in calculating specificEnthalpy because
it is the denominator.

inletMassFlow (and inletEnergyFlow) can be 0.0 when coming from PRV.

